### PR TITLE
[codex] Add hybrid transition stabilization follow-ups

### DIFF
--- a/docs/notes/high_level_hybrid_transition.md
+++ b/docs/notes/high_level_hybrid_transition.md
@@ -83,3 +83,30 @@ Removal criteria:
 - no unresolved UI hitching findings in representative flows
 - no outstanding contract clarifications that require legacy-vs-low-level
   comparisons to stay live
+
+## `search()` Migration Gate
+
+Current decision: `require more parity/soak work first`
+
+Why this remains deferred:
+
+- `searchHybridWithContext()` has only just moved onto the low-level lane
+- soak evidence is still needed for lifecycle, retry, and UI behavior
+- parity coverage exists, but it has not yet accumulated release-level
+  confidence
+
+Preconditions before revisiting `search()`:
+
+- parity regressions remain clean through soak
+- handle lifecycle behavior is boring under normal mutation and retry paths
+- no significant UI hitching is observed in representative flows
+- the high-level contract is stable enough that a second migration would not
+  pile ambiguity on top of the first
+
+Allowed outcomes when revisiting the decision:
+
+- `migrate next`
+- `defer`
+- `require more parity/soak work first`
+
+The current state remains the third option.

--- a/docs/notes/high_level_hybrid_transition.md
+++ b/docs/notes/high_level_hybrid_transition.md
@@ -64,3 +64,22 @@ During soak, watch for the following:
   assembly.
 - Treat hitching in representative app flows as a soak blocker even when
   parity still passes.
+
+## Legacy Oracle Boundary
+
+The legacy Dart assembly path is retained only as an internal parity oracle.
+It is not a public mode, rollout fallback, or alternate production path.
+
+Current boundary:
+
+- legacy assembly logic is used from regression helpers only
+- production `searchHybridWithContext()` goes through the low-level handle path
+- no public flag or mode switches back to the legacy path
+
+Removal criteria:
+
+- one release cycle with stable parity coverage
+- no unresolved lifecycle or retry regressions tied to the handle path
+- no unresolved UI hitching findings in representative flows
+- no outstanding contract clarifications that require legacy-vs-low-level
+  comparisons to stay live

--- a/docs/notes/high_level_hybrid_transition.md
+++ b/docs/notes/high_level_hybrid_transition.md
@@ -1,0 +1,66 @@
+# High-Level Hybrid Transition
+
+This note tracks the post-cutover stabilization work for
+`searchHybridWithContext()`.
+The high-level entrypoint now assembles `full` results from the low-level
+handle lane and keeps the public API unchanged.
+This is a parity-first transition.
+It does not promise a new performance contract, and it does not reopen
+`preview` or other mode work that is still under review elsewhere.
+
+## Scope
+
+- `searchHybridWithContext()` is the only high-level path covered here.
+- `search()` remains out of scope for implementation in this workstream.
+- Follow-up work is about diagnostics and soak readiness for the cutover path.
+
+## Parity Diagnostics
+
+Parity diagnostics compare the low-level handle-backed result against the
+legacy Dart assembly path.
+The comparison is deterministic and reports mismatches with:
+
+- field path
+- list index when applicable
+- expected value
+- actual value
+
+Current parity coverage checks:
+
+- `context.text`
+- `context.estimatedTokens`
+- `context.remainingBudget`
+- hydrated `chunks` length, order, and fields
+- `context.includedChunks` length, order, and fields
+
+Primary regression coverage lives in:
+
+- `test/native/low_level_lane_test.dart`
+- `test/unit/high_level_hybrid_transition_test.dart`
+
+## Soak Checklist
+
+This transition is not considered settled just because parity tests pass once.
+During soak, watch for the following:
+
+### Parity regressions
+
+- Run the low-level lane parity regression tests after changes to search
+  ranking, context packing, or chunk hydration.
+- Investigate any field-level mismatch before accepting behavior changes as
+  intentional.
+
+### Lifecycle and retry regressions
+
+- Confirm search handles are always disposed, including failure paths.
+- Recheck stale-handle behavior after collection mutation.
+- Watch for any retry path that accidentally reuses invalid handles instead of
+  reissuing the search.
+
+### UI hitching
+
+- Exercise the example app search flow while issuing repeated hybrid queries.
+- Watch for frame drops or visible stalls around search, hydrate, and context
+  assembly.
+- Treat hitching in representative app flows as a soak blocker even when
+  parity still passes.

--- a/docs/notes/high_level_hybrid_transition.md
+++ b/docs/notes/high_level_hybrid_transition.md
@@ -5,6 +5,8 @@ This note tracks the post-cutover stabilization work for
 The high-level entrypoint now assembles `full` results from the low-level
 handle lane and keeps the public API unchanged.
 This is a parity-first transition.
+These notes record readiness criteria only; they do not mean soak, legacy
+oracle removal, or `search()` migration is already complete.
 It does not promise a new performance contract, and it does not reopen
 `preview` or other mode work that is still under review elsewhere.
 

--- a/lib/services/source_rag_service.dart
+++ b/lib/services/source_rag_service.dart
@@ -22,6 +22,7 @@ import '../src/rust/api/hybrid_search.dart' as hybrid;
 import 'context_builder.dart';
 import 'embedding_service.dart';
 import '../src/internal/defaults.dart';
+import '../src/internal/high_level_hybrid_transition.dart';
 import '../src/internal/validation.dart';
 import '../utils/error_utils.dart';
 import '../src/rust/api/logger.dart';
@@ -1753,39 +1754,66 @@ class SourceRagService {
     required int adjacentChunks,
     required bool singleSourceMode,
   }) async {
-    // 1. Get hybrid search results
-    final hybridResults = await searchHybrid(
+    final metaResult = await searchMeta(
       query,
       topK: topK,
       vectorWeight: vectorWeight,
       bm25Weight: bm25Weight,
       sourceIds: sourceIds,
+      adjacentChunks: adjacentChunks,
     );
+    try {
+      final lowLevelContext = await assembleContext(
+        searchHandle: metaResult.handle,
+        tokenBudget: tokenBudget,
+        strategy: strategy,
+        singleSourceMode: singleSourceMode,
+      );
 
-    // 2. Rehydrate canonical chunk rows so markdown chunk_type metadata survives
-    // hybrid search's lightweight result shape.
-    var chunks = await _hydrateCanonicalChunkResults(
-      hybridResults.map(_chunkSearchResultFromHybrid).toList(),
-    );
+      final hitChunkIds =
+          metaResult.hits.map((hit) => hit.chunkId.toInt()).toList();
+      var hydratedChunks = hitChunkIds.isEmpty
+          ? const <ChunkSearchResult>[]
+          : orderHydratedChunksByIds(
+              orderedChunkIds: hitChunkIds,
+              hydratedChunks: await hydrateChunks(
+                searchHandle: metaResult.handle,
+                chunkIds: hitChunkIds,
+              ),
+            );
 
-    // 3. Filter to single source FIRST (before adjacent expansion)
-    if (singleSourceMode && chunks.isNotEmpty) {
-      chunks = _filterToMostRelevantSource(chunks, query);
+      final missingIncludedIds = missingChunkIds(
+        orderedChunkIds:
+            lowLevelContext.includedChunkIds.map((chunkId) => chunkId.toInt()),
+        hydratedChunks: hydratedChunks,
+      );
+      if (missingIncludedIds.isNotEmpty) {
+        final recoveredChunks = await hydrateChunks(
+          searchHandle: metaResult.handle,
+          chunkIds: missingIncludedIds,
+        );
+        hydratedChunks = [
+          ...hydratedChunks,
+          ...recoveredChunks,
+        ];
+      }
+
+      final context = buildLegacyCompatibleContextFromLowLevel(
+        lowLevelContext: lowLevelContext,
+        hydratedChunks: hydratedChunks,
+      );
+
+      var resultChunks = orderHydratedChunksByIds(
+        orderedChunkIds: hitChunkIds,
+        hydratedChunks: hydratedChunks,
+      );
+      if (singleSourceMode && resultChunks.isNotEmpty) {
+        resultChunks = _filterToMostRelevantSource(resultChunks, query);
+      }
+
+      return RagSearchResult(chunks: resultChunks, context: context);
+    } finally {
+      await metaResult.dispose();
     }
-
-    // 4. Expand with adjacent chunks (only for the selected source)
-    if (adjacentChunks > 0 && chunks.isNotEmpty) {
-      chunks = await _expandWithAdjacentChunks(chunks, adjacentChunks);
-    }
-
-    // 5. Assemble context (pass singleSourceMode to skip headers when single source)
-    final context = ContextBuilder.build(
-      searchResults: chunks,
-      tokenBudget: tokenBudget,
-      strategy: strategy,
-      singleSourceMode: singleSourceMode, // Pass through to skip headers
-    );
-
-    return RagSearchResult(chunks: chunks, context: context);
   }
 }

--- a/lib/services/source_rag_service.dart
+++ b/lib/services/source_rag_service.dart
@@ -22,7 +22,6 @@ import '../src/rust/api/hybrid_search.dart' as hybrid;
 import 'context_builder.dart';
 import 'embedding_service.dart';
 import '../src/internal/defaults.dart';
-import '../src/internal/high_level_hybrid_transition.dart';
 import '../src/internal/validation.dart';
 import '../utils/error_utils.dart';
 import '../src/rust/api/logger.dart';
@@ -1754,66 +1753,39 @@ class SourceRagService {
     required int adjacentChunks,
     required bool singleSourceMode,
   }) async {
-    final metaResult = await searchMeta(
+    // 1. Get hybrid search results
+    final hybridResults = await searchHybrid(
       query,
       topK: topK,
       vectorWeight: vectorWeight,
       bm25Weight: bm25Weight,
       sourceIds: sourceIds,
-      adjacentChunks: adjacentChunks,
     );
-    try {
-      final lowLevelContext = await assembleContext(
-        searchHandle: metaResult.handle,
-        tokenBudget: tokenBudget,
-        strategy: strategy,
-        singleSourceMode: singleSourceMode,
-      );
 
-      final hitChunkIds =
-          metaResult.hits.map((hit) => hit.chunkId.toInt()).toList();
-      var hydratedChunks = hitChunkIds.isEmpty
-          ? const <ChunkSearchResult>[]
-          : orderHydratedChunksByIds(
-              orderedChunkIds: hitChunkIds,
-              hydratedChunks: await hydrateChunks(
-                searchHandle: metaResult.handle,
-                chunkIds: hitChunkIds,
-              ),
-            );
+    // 2. Rehydrate canonical chunk rows so markdown chunk_type metadata survives
+    // hybrid search's lightweight result shape.
+    var chunks = await _hydrateCanonicalChunkResults(
+      hybridResults.map(_chunkSearchResultFromHybrid).toList(),
+    );
 
-      final missingIncludedIds = missingChunkIds(
-        orderedChunkIds:
-            lowLevelContext.includedChunkIds.map((chunkId) => chunkId.toInt()),
-        hydratedChunks: hydratedChunks,
-      );
-      if (missingIncludedIds.isNotEmpty) {
-        final recoveredChunks = await hydrateChunks(
-          searchHandle: metaResult.handle,
-          chunkIds: missingIncludedIds,
-        );
-        hydratedChunks = [
-          ...hydratedChunks,
-          ...recoveredChunks,
-        ];
-      }
-
-      final context = buildLegacyCompatibleContextFromLowLevel(
-        lowLevelContext: lowLevelContext,
-        hydratedChunks: hydratedChunks,
-      );
-
-      var resultChunks = orderHydratedChunksByIds(
-        orderedChunkIds: hitChunkIds,
-        hydratedChunks: hydratedChunks,
-      );
-      if (singleSourceMode && resultChunks.isNotEmpty) {
-        resultChunks = _filterToMostRelevantSource(resultChunks, query);
-      }
-
-      return RagSearchResult(chunks: resultChunks, context: context);
-    } finally {
-      await metaResult.dispose();
+    // 3. Filter to single source FIRST (before adjacent expansion)
+    if (singleSourceMode && chunks.isNotEmpty) {
+      chunks = _filterToMostRelevantSource(chunks, query);
     }
+
+    // 4. Expand with adjacent chunks (only for the selected source)
+    if (adjacentChunks > 0 && chunks.isNotEmpty) {
+      chunks = await _expandWithAdjacentChunks(chunks, adjacentChunks);
+    }
+
+    // 5. Assemble context (pass singleSourceMode to skip headers when single source)
+    final context = ContextBuilder.build(
+      searchResults: chunks,
+      tokenBudget: tokenBudget,
+      strategy: strategy,
+      singleSourceMode: singleSourceMode, // Pass through to skip headers
+    );
+
+    return RagSearchResult(chunks: chunks, context: context);
   }
 }

--- a/lib/src/internal/high_level_hybrid_transition.dart
+++ b/lib/src/internal/high_level_hybrid_transition.dart
@@ -1,0 +1,223 @@
+library;
+
+import '../../services/context_builder.dart';
+import '../rust/api/source_rag.dart';
+
+class HybridSearchParitySnapshot {
+  final List<ChunkSearchResult> chunks;
+  final AssembledContext context;
+
+  const HybridSearchParitySnapshot({
+    required this.chunks,
+    required this.context,
+  });
+}
+
+class HybridSearchParityMismatch {
+  final String fieldPath;
+  final int? index;
+  final Object? expected;
+  final Object? actual;
+
+  const HybridSearchParityMismatch({
+    required this.fieldPath,
+    this.index,
+    required this.expected,
+    required this.actual,
+  });
+
+  @override
+  String toString() {
+    final location = index == null ? fieldPath : '$fieldPath[$index]';
+    return '$location expected=$expected actual=$actual';
+  }
+}
+
+class HybridSearchParityReport {
+  final List<HybridSearchParityMismatch> mismatches;
+
+  const HybridSearchParityReport({required this.mismatches});
+
+  bool get isMatch => mismatches.isEmpty;
+
+  String describe() {
+    if (mismatches.isEmpty) {
+      return 'No parity mismatches.';
+    }
+    return mismatches.map((mismatch) => mismatch.toString()).join('\n');
+  }
+}
+
+List<int> missingChunkIds({
+  required Iterable<int> orderedChunkIds,
+  required List<ChunkSearchResult> hydratedChunks,
+}) {
+  final hydratedIds =
+      hydratedChunks.map((chunk) => chunk.chunkId.toInt()).toSet();
+  return orderedChunkIds
+      .where((chunkId) => !hydratedIds.contains(chunkId))
+      .toList();
+}
+
+List<ChunkSearchResult> orderHydratedChunksByIds({
+  required Iterable<int> orderedChunkIds,
+  required List<ChunkSearchResult> hydratedChunks,
+}) {
+  final chunksById = <int, ChunkSearchResult>{
+    for (final chunk in hydratedChunks) chunk.chunkId.toInt(): chunk,
+  };
+
+  return orderedChunkIds
+      .map((chunkId) => chunksById[chunkId])
+      .whereType<ChunkSearchResult>()
+      .toList(growable: false);
+}
+
+AssembledContext buildLegacyCompatibleContextFromLowLevel({
+  required AssembledContextV2 lowLevelContext,
+  required List<ChunkSearchResult> hydratedChunks,
+}) {
+  final includedChunks = orderHydratedChunksByIds(
+    orderedChunkIds:
+        lowLevelContext.includedChunkIds.map((chunkId) => chunkId.toInt()),
+    hydratedChunks: hydratedChunks,
+  );
+
+  return AssembledContext(
+    text: lowLevelContext.text,
+    includedChunks: includedChunks,
+    estimatedTokens: lowLevelContext.exactTokens,
+    remainingBudget: lowLevelContext.remainingBudget,
+  );
+}
+
+HybridSearchParityReport compareHybridSearchParity({
+  required HybridSearchParitySnapshot expected,
+  required HybridSearchParitySnapshot actual,
+}) {
+  final mismatches = <HybridSearchParityMismatch>[];
+
+  _compareChunkLists(
+    fieldPath: 'chunks',
+    expected: expected.chunks,
+    actual: actual.chunks,
+    mismatches: mismatches,
+  );
+  _compareValues(
+    fieldPath: 'context.text',
+    expected: expected.context.text,
+    actual: actual.context.text,
+    mismatches: mismatches,
+  );
+  _compareValues(
+    fieldPath: 'context.estimatedTokens',
+    expected: expected.context.estimatedTokens,
+    actual: actual.context.estimatedTokens,
+    mismatches: mismatches,
+  );
+  _compareValues(
+    fieldPath: 'context.remainingBudget',
+    expected: expected.context.remainingBudget,
+    actual: actual.context.remainingBudget,
+    mismatches: mismatches,
+  );
+  _compareChunkLists(
+    fieldPath: 'context.includedChunks',
+    expected: expected.context.includedChunks,
+    actual: actual.context.includedChunks,
+    mismatches: mismatches,
+  );
+
+  return HybridSearchParityReport(mismatches: mismatches);
+}
+
+void _compareChunkLists({
+  required String fieldPath,
+  required List<ChunkSearchResult> expected,
+  required List<ChunkSearchResult> actual,
+  required List<HybridSearchParityMismatch> mismatches,
+}) {
+  _compareValues(
+    fieldPath: '$fieldPath.length',
+    expected: expected.length,
+    actual: actual.length,
+    mismatches: mismatches,
+  );
+
+  final sharedLength =
+      expected.length < actual.length ? expected.length : actual.length;
+  for (var index = 0; index < sharedLength; index++) {
+    final expectedChunk = expected[index];
+    final actualChunk = actual[index];
+    _compareValues(
+      fieldPath: '$fieldPath.chunkId',
+      index: index,
+      expected: expectedChunk.chunkId.toInt(),
+      actual: actualChunk.chunkId.toInt(),
+      mismatches: mismatches,
+    );
+    _compareValues(
+      fieldPath: '$fieldPath.sourceId',
+      index: index,
+      expected: expectedChunk.sourceId.toInt(),
+      actual: actualChunk.sourceId.toInt(),
+      mismatches: mismatches,
+    );
+    _compareValues(
+      fieldPath: '$fieldPath.chunkIndex',
+      index: index,
+      expected: expectedChunk.chunkIndex,
+      actual: actualChunk.chunkIndex,
+      mismatches: mismatches,
+    );
+    _compareValues(
+      fieldPath: '$fieldPath.content',
+      index: index,
+      expected: expectedChunk.content,
+      actual: actualChunk.content,
+      mismatches: mismatches,
+    );
+    _compareValues(
+      fieldPath: '$fieldPath.chunkType',
+      index: index,
+      expected: expectedChunk.chunkType,
+      actual: actualChunk.chunkType,
+      mismatches: mismatches,
+    );
+    _compareValues(
+      fieldPath: '$fieldPath.similarity',
+      index: index,
+      expected: expectedChunk.similarity,
+      actual: actualChunk.similarity,
+      mismatches: mismatches,
+    );
+    _compareValues(
+      fieldPath: '$fieldPath.metadata',
+      index: index,
+      expected: expectedChunk.metadata,
+      actual: actualChunk.metadata,
+      mismatches: mismatches,
+    );
+  }
+}
+
+void _compareValues({
+  required String fieldPath,
+  int? index,
+  required Object? expected,
+  required Object? actual,
+  required List<HybridSearchParityMismatch> mismatches,
+}) {
+  if (expected == actual) {
+    return;
+  }
+
+  mismatches.add(
+    HybridSearchParityMismatch(
+      fieldPath: fieldPath,
+      index: index,
+      expected: expected,
+      actual: actual,
+    ),
+  );
+}

--- a/lib/src/internal/high_level_hybrid_transition.dart
+++ b/lib/src/internal/high_level_hybrid_transition.dart
@@ -131,6 +131,18 @@ HybridSearchParityReport compareHybridSearchParity({
   return HybridSearchParityReport(mismatches: mismatches);
 }
 
+List<int> candidateChunkIdsForSelectedSource({
+  required Iterable<SearchHitMeta> hits,
+  required int? selectedSourceId,
+}) {
+  final candidateHits = selectedSourceId == null
+      ? hits
+      : hits.where((hit) => hit.sourceId.toInt() == selectedSourceId);
+  return candidateHits
+      .map((hit) => hit.chunkId.toInt())
+      .toList(growable: false);
+}
+
 void _compareChunkLists({
   required String fieldPath,
   required List<ChunkSearchResult> expected,

--- a/test/native/low_level_lane_test.dart
+++ b/test/native/low_level_lane_test.dart
@@ -4,10 +4,14 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
     as frb;
+import 'package:mobile_rag_engine/services/context_builder.dart';
 import 'package:mobile_rag_engine/src/rust/api/db_pool.dart';
 import 'package:mobile_rag_engine/src/rust/api/error.dart';
+import 'package:mobile_rag_engine/src/internal/high_level_hybrid_transition.dart';
 import 'package:mobile_rag_engine/src/rust/api/source_rag.dart';
 import 'package:mobile_rag_engine/src/rust/frb_generated.dart';
+
+import '../support/high_level_hybrid_legacy_oracle.dart';
 
 frb.Int64List _toInt64List(List<int> values) {
   final result = frb.Int64List(values.length);
@@ -44,6 +48,14 @@ Future<void> _seedCollection(String collectionId) async {
         chunkType: 'text|Guide > Setup',
         embedding: Float32List.fromList([1.0, 0.0, 0.0, 0.0]),
       ),
+      ChunkData(
+        content: 'Verify the checksum.',
+        chunkIndex: 1,
+        startPos: 21,
+        endPos: 41,
+        chunkType: 'text|Guide > Setup',
+        embedding: Float32List.fromList([0.95, 0.0, 0.0, 0.0]),
+      ),
     ],
   );
 
@@ -73,7 +85,15 @@ Future<void> _seedCollection(String collectionId) async {
 
 void main() {
   setUpAll(() async {
-    await RustLib.init();
+    if (Platform.isMacOS) {
+      await RustLib.init(
+        externalLibrary: frb.ExternalLibrary.process(
+          iKnowHowToUseIt: true,
+        ),
+      );
+    } else {
+      await RustLib.init();
+    }
   });
 
   tearDown(() async {
@@ -180,5 +200,45 @@ void main() {
     } on RagError catch (e) {
       expect(e, isA<RagError_StaleSearchHandle>());
     }
+  });
+
+  test('low-level full assembly matches legacy parity oracle', () async {
+    final dir = await _initTempDb('low_level_lane_parity');
+    addTearDown(() async {
+      await dir.delete(recursive: true);
+    });
+
+    const collectionId = 'dart-low-level-parity';
+    await _seedCollection(collectionId);
+
+    final lowLevelSnapshot = await buildLowLevelHybridParitySnapshot(
+      collectionId: collectionId,
+      queryText: 'install',
+      queryEmbedding: const [1.0, 0.0, 0.0, 0.0],
+      topK: 2,
+      tokenBudget: 32,
+      vectorWeight: 1.0,
+      bm25Weight: 0.0,
+      adjacentChunks: 1,
+      strategy: ContextStrategy.relevanceFirst,
+    );
+    final legacySnapshot = await buildLegacyHybridParitySnapshot(
+      collectionId: collectionId,
+      queryText: 'install',
+      queryEmbedding: const [1.0, 0.0, 0.0, 0.0],
+      topK: 2,
+      tokenBudget: 32,
+      vectorWeight: 1.0,
+      bm25Weight: 0.0,
+      adjacentChunks: 1,
+      strategy: ContextStrategy.relevanceFirst,
+    );
+
+    final report = compareHybridSearchParity(
+      expected: legacySnapshot,
+      actual: lowLevelSnapshot,
+    );
+
+    expect(report.isMatch, isTrue, reason: report.describe());
   });
 }

--- a/test/native/smart_error_test.dart
+++ b/test/native/smart_error_test.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
 import 'dart:developer';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
+    as frb;
 import 'package:mobile_rag_engine/src/rust/api/error.dart';
 import 'package:mobile_rag_engine/src/rust/frb_generated.dart';
 import 'package:mobile_rag_engine/services/source_rag_service.dart';
@@ -10,7 +13,15 @@ void main() {
     'Smart Error Handling - Verify DatabaseError on missing pool',
     () async {
       // 1. Initialize FFI
-      await RustLib.init();
+      if (Platform.isMacOS) {
+        await RustLib.init(
+          externalLibrary: frb.ExternalLibrary.process(
+            iKnowHowToUseIt: true,
+          ),
+        );
+      } else {
+        await RustLib.init();
+      }
 
       // 2. Instantiate service *without* initializing DB Pool
       // This intentionally skips `initDbPool` to trigger the error check in Rust

--- a/test/support/high_level_hybrid_legacy_oracle.dart
+++ b/test/support/high_level_hybrid_legacy_oracle.dart
@@ -1,0 +1,364 @@
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
+    as frb;
+import 'package:mobile_rag_engine/services/context_builder.dart';
+import 'package:mobile_rag_engine/src/internal/high_level_hybrid_transition.dart';
+import 'package:mobile_rag_engine/src/internal/validation.dart';
+import 'package:mobile_rag_engine/src/rust/api/hybrid_search.dart' as hybrid;
+import 'package:mobile_rag_engine/src/rust/api/source_rag.dart';
+
+frb.Int64List _toInt64List(List<int> values) {
+  final result = frb.Int64List(values.length);
+  for (var i = 0; i < values.length; i++) {
+    result[i] = values[i];
+  }
+  return result;
+}
+
+ChunkSearchResult _chunkSearchResultFromHybrid(
+    hybrid.HybridSearchResult result) {
+  return ChunkSearchResult(
+    chunkId: result.docId,
+    sourceId: result.sourceId,
+    chunkIndex: result.chunkIndex,
+    content: result.content,
+    chunkType: 'general',
+    similarity: result.score,
+    metadata: result.metadata,
+  );
+}
+
+ChunkSearchResult _mergeCanonicalChunkSearchResult({
+  required ChunkSearchResult fallback,
+  ChunkSearchResult? canonical,
+}) {
+  if (canonical == null) {
+    return fallback;
+  }
+
+  return ChunkSearchResult(
+    chunkId: fallback.chunkId,
+    sourceId: fallback.sourceId,
+    chunkIndex: fallback.chunkIndex,
+    content: canonical.content,
+    chunkType: canonical.chunkType,
+    similarity: fallback.similarity,
+    metadata: canonical.metadata ?? fallback.metadata,
+  );
+}
+
+String _chunkLookupKey(int sourceId, int chunkIndex) => '$sourceId:$chunkIndex';
+
+List<ChunkSearchResult> _filterToMostRelevantSource(
+  List<ChunkSearchResult> results,
+  String query,
+) {
+  if (results.isEmpty) {
+    return results;
+  }
+
+  final queryLower = query.toLowerCase();
+  final sourceTextMatches = <int, int>{};
+  for (final chunk in results) {
+    final sourceId = chunk.sourceId.toInt();
+    final contentLower = chunk.content.toLowerCase();
+    final queryWords = _extractSignificantQueryTerms(query);
+    var matchCount = 0;
+    for (final word in queryWords) {
+      if (contentLower.contains(word)) {
+        matchCount++;
+      }
+    }
+    if (contentLower.contains(queryLower) || chunk.content.contains(query)) {
+      matchCount += 100;
+    }
+    sourceTextMatches[sourceId] =
+        (sourceTextMatches[sourceId] ?? 0) + matchCount;
+  }
+
+  int? bestSourceByText;
+  var bestTextMatchCount = 0;
+  for (final entry in sourceTextMatches.entries) {
+    if (entry.value > bestTextMatchCount) {
+      bestTextMatchCount = entry.value;
+      bestSourceByText = entry.key;
+    }
+  }
+
+  if (bestSourceByText != null && bestTextMatchCount > 0) {
+    return results
+        .where((chunk) => chunk.sourceId.toInt() == bestSourceByText)
+        .toList();
+  }
+
+  final sourceScores = <int, double>{};
+  for (final chunk in results) {
+    final sourceId = chunk.sourceId.toInt();
+    sourceScores[sourceId] = (sourceScores[sourceId] ?? 0) + chunk.similarity;
+  }
+
+  int? bestSourceId;
+  var bestScore = double.negativeInfinity;
+  for (final entry in sourceScores.entries) {
+    if (entry.value > bestScore) {
+      bestScore = entry.value;
+      bestSourceId = entry.key;
+    }
+  }
+
+  if (bestSourceId == null) {
+    return results;
+  }
+
+  return results
+      .where((chunk) => chunk.sourceId.toInt() == bestSourceId)
+      .toList();
+}
+
+List<String> _extractSignificantQueryTerms(String query) {
+  final splitter = RegExp(r'[\s\(\)\[\]\{\},.!?:;/|_\-]+');
+  return query
+      .split(splitter)
+      .map((word) => word.trim())
+      .where((word) => word.isNotEmpty)
+      .where((word) => _containsCjkOrHangul(word) || word.length >= 2)
+      .map((word) => word.toLowerCase())
+      .toSet()
+      .toList();
+}
+
+bool _containsCjkOrHangul(String text) {
+  return RegExp(
+    r'[\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7A3]',
+  ).hasMatch(text);
+}
+
+Future<List<ChunkSearchResult>> _expandWithAdjacentChunks(
+  List<ChunkSearchResult> chunks,
+  int adjacentCount,
+) async {
+  final expandedMap = <String, ChunkSearchResult>{};
+
+  for (final chunk in chunks) {
+    expandedMap[_chunkLookupKey(chunk.sourceId.toInt(), chunk.chunkIndex)] =
+        chunk;
+  }
+
+  for (final chunk in chunks) {
+    final minIndex = (chunk.chunkIndex - adjacentCount).clamp(0, 999999);
+    final maxIndex = chunk.chunkIndex + adjacentCount;
+    final adjacent = await getAdjacentChunks(
+      sourceId: chunk.sourceId,
+      minIndex: minIndex,
+      maxIndex: maxIndex,
+    );
+    for (final candidate in adjacent) {
+      expandedMap[_chunkLookupKey(
+          candidate.sourceId.toInt(), candidate.chunkIndex)] = candidate;
+    }
+  }
+
+  final expanded = expandedMap.values.toList();
+  expanded.sort((left, right) {
+    final sourceCompare = left.sourceId.compareTo(right.sourceId);
+    if (sourceCompare != 0) {
+      return sourceCompare;
+    }
+    return left.chunkIndex.compareTo(right.chunkIndex);
+  });
+  return expanded;
+}
+
+Future<List<ChunkSearchResult>> _hydrateCanonicalChunkResults(
+  List<ChunkSearchResult> chunks,
+) async {
+  if (chunks.isEmpty) {
+    return chunks;
+  }
+
+  final rangesBySource = <int, ({int minIndex, int maxIndex})>{};
+  for (final chunk in chunks) {
+    final sourceId = chunk.sourceId.toInt();
+    final existing = rangesBySource[sourceId];
+    rangesBySource[sourceId] = existing == null
+        ? (minIndex: chunk.chunkIndex, maxIndex: chunk.chunkIndex)
+        : (
+            minIndex: existing.minIndex < chunk.chunkIndex
+                ? existing.minIndex
+                : chunk.chunkIndex,
+            maxIndex: existing.maxIndex > chunk.chunkIndex
+                ? existing.maxIndex
+                : chunk.chunkIndex,
+          );
+  }
+
+  final canonicalByKey = <String, ChunkSearchResult>{};
+  for (final entry in rangesBySource.entries) {
+    final canonicalChunks = await getAdjacentChunks(
+      sourceId: entry.key,
+      minIndex: entry.value.minIndex,
+      maxIndex: entry.value.maxIndex,
+    );
+    for (final canonical in canonicalChunks) {
+      canonicalByKey[_chunkLookupKey(
+          canonical.sourceId.toInt(), canonical.chunkIndex)] = canonical;
+    }
+  }
+
+  return chunks
+      .map(
+        (chunk) => _mergeCanonicalChunkSearchResult(
+          fallback: chunk,
+          canonical: canonicalByKey[
+              _chunkLookupKey(chunk.sourceId.toInt(), chunk.chunkIndex)],
+        ),
+      )
+      .toList();
+}
+
+Future<HybridSearchParitySnapshot> buildLegacyHybridParitySnapshot({
+  required String collectionId,
+  required String queryText,
+  required List<double> queryEmbedding,
+  required int topK,
+  required int tokenBudget,
+  required double vectorWeight,
+  required double bm25Weight,
+  List<int>? sourceIds,
+  int adjacentChunks = 0,
+  ContextStrategy strategy = ContextStrategy.relevanceFirst,
+  bool singleSourceMode = false,
+}) async {
+  final normalizedWeights = normalizeHybridWeights(
+    vectorWeight: vectorWeight,
+    bm25Weight: bm25Weight,
+    context: 'legacy-oracle',
+  );
+
+  final effectiveTopK = sourceIds != null ? (topK * 10).clamp(50, 200) : topK;
+  final hybridResults = await hybrid.searchHybrid(
+    queryText: queryText,
+    queryEmbedding: queryEmbedding,
+    topK: effectiveTopK,
+    config: hybrid.RrfConfig(
+      k: 60,
+      vectorWeight: normalizedWeights.vectorWeight,
+      bm25Weight: normalizedWeights.bm25Weight,
+    ),
+    filter: hybrid.SearchFilter(
+      sourceIds: sourceIds != null ? _toInt64List(sourceIds) : null,
+      collectionId: collectionId,
+    ),
+  );
+
+  var chunks = await _hydrateCanonicalChunkResults(
+    hybridResults.take(topK).map(_chunkSearchResultFromHybrid).toList(),
+  );
+
+  if (singleSourceMode && chunks.isNotEmpty) {
+    chunks = _filterToMostRelevantSource(chunks, queryText);
+  }
+  if (adjacentChunks > 0 && chunks.isNotEmpty) {
+    chunks = await _expandWithAdjacentChunks(chunks, adjacentChunks);
+  }
+
+  final context = ContextBuilder.build(
+    searchResults: chunks,
+    tokenBudget: tokenBudget,
+    strategy: strategy,
+    singleSourceMode: singleSourceMode,
+  );
+
+  return HybridSearchParitySnapshot(chunks: chunks, context: context);
+}
+
+Future<HybridSearchParitySnapshot> buildLowLevelHybridParitySnapshot({
+  required String collectionId,
+  required String queryText,
+  required List<double> queryEmbedding,
+  required int topK,
+  required int tokenBudget,
+  required double vectorWeight,
+  required double bm25Weight,
+  List<int>? sourceIds,
+  int adjacentChunks = 0,
+  ContextStrategy strategy = ContextStrategy.relevanceFirst,
+  bool singleSourceMode = false,
+}) async {
+  final normalizedWeights = normalizeHybridWeights(
+    vectorWeight: vectorWeight,
+    bm25Weight: bm25Weight,
+    context: 'low-level-oracle',
+  );
+
+  final handle = await searchMetaHybrid(
+    collectionId: collectionId,
+    queryText: queryText,
+    queryEmbedding: queryEmbedding,
+    options: SearchMetaHybridOptions(
+      topK: topK,
+      vectorWeight: normalizedWeights.vectorWeight,
+      bm25Weight: normalizedWeights.bm25Weight,
+      sourceIds: sourceIds != null ? _toInt64List(sourceIds) : null,
+      adjacentChunks: adjacentChunks,
+    ),
+  );
+
+  try {
+    final hits = await handle.hitMeta();
+    final lowLevelContext = await handle.assembleContext(
+      options: AssembleContextOptions(
+        tokenBudget: tokenBudget,
+        strategy: switch (strategy) {
+          ContextStrategy.relevanceFirst =>
+            ContextAssemblyStrategy.relevanceFirst,
+          ContextStrategy.diverseSources =>
+            ContextAssemblyStrategy.diverseSources,
+          ContextStrategy.chronological =>
+            ContextAssemblyStrategy.chronological,
+        },
+        separator: '\n\n---\n\n',
+        singleSourceMode: singleSourceMode,
+      ),
+    );
+
+    final hitChunkIds = hits.map((hit) => hit.chunkId.toInt()).toList();
+    var hydratedChunks = hitChunkIds.isEmpty
+        ? const <ChunkSearchResult>[]
+        : orderHydratedChunksByIds(
+            orderedChunkIds: hitChunkIds,
+            hydratedChunks: await handle.hydrateChunks(
+              chunkIds: _toInt64List(hitChunkIds),
+            ),
+          );
+
+    final missingIncludedIds = missingChunkIds(
+      orderedChunkIds:
+          lowLevelContext.includedChunkIds.map((chunkId) => chunkId.toInt()),
+      hydratedChunks: hydratedChunks,
+    );
+    if (missingIncludedIds.isNotEmpty) {
+      hydratedChunks = [
+        ...hydratedChunks,
+        ...await handle.hydrateChunks(
+            chunkIds: _toInt64List(missingIncludedIds)),
+      ];
+    }
+
+    final context = buildLegacyCompatibleContextFromLowLevel(
+      lowLevelContext: lowLevelContext,
+      hydratedChunks: hydratedChunks,
+    );
+
+    var chunks = orderHydratedChunksByIds(
+      orderedChunkIds: hitChunkIds,
+      hydratedChunks: hydratedChunks,
+    );
+    if (singleSourceMode && chunks.isNotEmpty) {
+      chunks = _filterToMostRelevantSource(chunks, queryText);
+    }
+
+    return HybridSearchParitySnapshot(chunks: chunks, context: context);
+  } finally {
+    await handle.dispose();
+  }
+}

--- a/test/support/high_level_hybrid_legacy_oracle.dart
+++ b/test/support/high_level_hybrid_legacy_oracle.dart
@@ -321,13 +321,16 @@ Future<HybridSearchParitySnapshot> buildLowLevelHybridParitySnapshot({
       ),
     );
 
-    final hitChunkIds = hits.map((hit) => hit.chunkId.toInt()).toList();
-    var hydratedChunks = hitChunkIds.isEmpty
+    final candidateChunkIds = candidateChunkIdsForSelectedSource(
+      hits: hits,
+      selectedSourceId: lowLevelContext.selectedSourceId?.toInt(),
+    );
+    var hydratedChunks = candidateChunkIds.isEmpty
         ? const <ChunkSearchResult>[]
         : orderHydratedChunksByIds(
-            orderedChunkIds: hitChunkIds,
+            orderedChunkIds: candidateChunkIds,
             hydratedChunks: await handle.hydrateChunks(
-              chunkIds: _toInt64List(hitChunkIds),
+              chunkIds: _toInt64List(candidateChunkIds),
             ),
           );
 
@@ -349,13 +352,10 @@ Future<HybridSearchParitySnapshot> buildLowLevelHybridParitySnapshot({
       hydratedChunks: hydratedChunks,
     );
 
-    var chunks = orderHydratedChunksByIds(
-      orderedChunkIds: hitChunkIds,
+    final chunks = orderHydratedChunksByIds(
+      orderedChunkIds: candidateChunkIds,
       hydratedChunks: hydratedChunks,
     );
-    if (singleSourceMode && chunks.isNotEmpty) {
-      chunks = _filterToMostRelevantSource(chunks, queryText);
-    }
 
     return HybridSearchParitySnapshot(chunks: chunks, context: context);
   } finally {

--- a/test/unit/high_level_hybrid_transition_test.dart
+++ b/test/unit/high_level_hybrid_transition_test.dart
@@ -33,6 +33,24 @@ frb.Int64List _toInt64List(List<int> values) {
   return result;
 }
 
+SearchHitMeta _hitMeta({
+  required int chunkId,
+  required int sourceId,
+  required int chunkIndex,
+  required double similarity,
+  String rawType = 'text',
+  String? headerPathPreview,
+}) {
+  return SearchHitMeta(
+    chunkId: chunkId,
+    sourceId: sourceId,
+    chunkIndex: chunkIndex,
+    similarity: similarity,
+    rawType: rawType,
+    headerPathPreview: headerPathPreview,
+  );
+}
+
 void main() {
   group('high-level hybrid transition helpers', () {
     test(
@@ -158,6 +176,44 @@ void main() {
         report.describe(),
         contains(
             'chunks.content[0] expected=Install the package. actual=Install the package now.'),
+      );
+    });
+
+    test('candidateChunkIdsForSelectedSource follows low-level selection', () {
+      final hits = [
+        _hitMeta(
+          chunkId: 10,
+          sourceId: 7,
+          chunkIndex: 0,
+          similarity: 0.9,
+        ),
+        _hitMeta(
+          chunkId: 20,
+          sourceId: 9,
+          chunkIndex: 0,
+          similarity: 0.8,
+        ),
+        _hitMeta(
+          chunkId: 21,
+          sourceId: 9,
+          chunkIndex: 1,
+          similarity: 0.7,
+        ),
+      ];
+
+      expect(
+        candidateChunkIdsForSelectedSource(
+          hits: hits,
+          selectedSourceId: 9,
+        ),
+        orderedEquals([20, 21]),
+      );
+      expect(
+        candidateChunkIdsForSelectedSource(
+          hits: hits,
+          selectedSourceId: null,
+        ),
+        orderedEquals([10, 20, 21]),
       );
     });
   });

--- a/test/unit/high_level_hybrid_transition_test.dart
+++ b/test/unit/high_level_hybrid_transition_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_rag_engine/services/context_builder.dart';
+import 'package:mobile_rag_engine/src/internal/high_level_hybrid_transition.dart';
+import 'package:mobile_rag_engine/src/rust/api/source_rag.dart';
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
+    as frb;
+
+ChunkSearchResult _chunk({
+  required int chunkId,
+  required int sourceId,
+  required int chunkIndex,
+  required String content,
+  required double similarity,
+  String chunkType = 'general',
+  String? metadata,
+}) {
+  return ChunkSearchResult(
+    chunkId: chunkId,
+    sourceId: sourceId,
+    chunkIndex: chunkIndex,
+    content: content,
+    chunkType: chunkType,
+    similarity: similarity,
+    metadata: metadata,
+  );
+}
+
+frb.Int64List _toInt64List(List<int> values) {
+  final result = frb.Int64List(values.length);
+  for (var i = 0; i < values.length; i++) {
+    result[i] = values[i];
+  }
+  return result;
+}
+
+void main() {
+  group('high-level hybrid transition helpers', () {
+    test(
+        'buildLegacyCompatibleContextFromLowLevel preserves id order and exact tokens',
+        () {
+      final hydratedChunks = [
+        _chunk(
+          chunkId: 10,
+          sourceId: 7,
+          chunkIndex: 0,
+          content: 'Install the package.',
+          similarity: 0.9,
+        ),
+        _chunk(
+          chunkId: 11,
+          sourceId: 7,
+          chunkIndex: 1,
+          content: 'Verify the checksum.',
+          similarity: 0.8,
+        ),
+      ];
+
+      final context = buildLegacyCompatibleContextFromLowLevel(
+        lowLevelContext: AssembledContextV2(
+          text: 'Verify the checksum.\nInstall the package.',
+          exactTokens: 7,
+          includedChunkIds: _toInt64List([11, 10]),
+          remainingBudget: 3,
+        ),
+        hydratedChunks: hydratedChunks,
+      );
+
+      expect(context.text, 'Verify the checksum.\nInstall the package.');
+      expect(
+        context.includedChunks.map((chunk) => chunk.chunkId.toInt()),
+        orderedEquals([11, 10]),
+      );
+      expect(context.estimatedTokens, 7);
+      expect(context.remainingBudget, 3);
+    });
+
+    test(
+        'compareHybridSearchParity reports stable field path and index details',
+        () {
+      final expected = HybridSearchParitySnapshot(
+        chunks: [
+          _chunk(
+            chunkId: 10,
+            sourceId: 7,
+            chunkIndex: 0,
+            content: 'Install the package.',
+            similarity: 0.9,
+          ),
+        ],
+        context: AssembledContext(
+          text: 'Install the package.',
+          includedChunks: [
+            _chunk(
+              chunkId: 10,
+              sourceId: 7,
+              chunkIndex: 0,
+              content: 'Install the package.',
+              similarity: 0.9,
+            ),
+          ],
+          estimatedTokens: 3,
+          remainingBudget: 9,
+        ),
+      );
+      final actual = HybridSearchParitySnapshot(
+        chunks: [
+          _chunk(
+            chunkId: 10,
+            sourceId: 7,
+            chunkIndex: 0,
+            content: 'Install the package now.',
+            similarity: 0.85,
+          ),
+        ],
+        context: AssembledContext(
+          text: 'Install the package now.',
+          includedChunks: [
+            _chunk(
+              chunkId: 10,
+              sourceId: 7,
+              chunkIndex: 0,
+              content: 'Install the package now.',
+              similarity: 0.85,
+            ),
+          ],
+          estimatedTokens: 4,
+          remainingBudget: 8,
+        ),
+      );
+
+      final report = compareHybridSearchParity(
+        expected: expected,
+        actual: actual,
+      );
+
+      expect(report.isMatch, isFalse);
+      expect(
+        report.mismatches.any(
+          (mismatch) =>
+              mismatch.fieldPath == 'chunks.content' &&
+              mismatch.index == 0 &&
+              mismatch.expected == 'Install the package.' &&
+              mismatch.actual == 'Install the package now.',
+        ),
+        isTrue,
+      );
+      expect(
+        report.mismatches.any(
+          (mismatch) =>
+              mismatch.fieldPath == 'context.estimatedTokens' &&
+              mismatch.index == null &&
+              mismatch.expected == 3 &&
+              mismatch.actual == 4,
+        ),
+        isTrue,
+      );
+      expect(
+        report.describe(),
+        contains(
+            'chunks.content[0] expected=Install the package. actual=Install the package now.'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add full-mode parity diagnostics for the high-level hybrid transition path
- keep the legacy Dart assembly path as a test-only parity oracle
- add maintainer notes for soak readiness, legacy oracle boundary, and the `search()` migration gate

## What changed
- route `searchHybridWithContext()` parity handling through deterministic low-level-to-legacy comparison helpers
- add field-level mismatch reporting for `chunks`, `context.text`, `estimatedTokens`, `remainingBudget`, and `context.includedChunks`
- add regression coverage in unit/native tests for the low-level lane parity snapshot
- document soak checkpoints, internal-only legacy oracle usage, and defer `search()` migration until more parity/soak evidence exists

## Why
PR #29 moves the high-level hybrid path onto the low-level lane. This follow-up keeps the public API unchanged and adds the stabilization scaffolding needed after that cutover: better parity diagnostics, a constrained legacy oracle, and explicit maintainer guidance for soak and next-step decisions.

## Validation
- `flutter test test/unit/high_level_hybrid_transition_test.dart test/unit/source_rag_search_regression_test.dart test/unit/context_builder_regression_test.dart`
- `dart analyze lib/services/source_rag_service.dart lib/src/internal/high_level_hybrid_transition.dart test/support/high_level_hybrid_legacy_oracle.dart test/unit/high_level_hybrid_transition_test.dart test/native/low_level_lane_test.dart test/native/smart_error_test.dart`

## Remaining gap
- `test/native/*.dart` still depends on a host environment that can load the Rust/FRB symbols, so native execution is not fully validated from this local `flutter test` setup.