### PR TITLE
chore: prepare 0.17.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.17.0
+* **Low-level APIs**:
+  - Added an additive metadata-first search lane with `searchMeta`, `assembleContext`, `hydrateChunks`, and `getChunkExcerpts`.
+  - Added `addDocumentUtf8` and `addDocumentFromFile` as ingest fast paths that reduce input-side string materialization.
+* **Search / Compatibility**:
+  - Preserved existing `search()` and `searchHybridWithContext()` semantics while introducing generation-pinned low-level handles underneath.
+  - Added deterministic stale-handle and concurrent-mutation error coverage for low-level search-handle operations.
+* **Compatibility**:
+  - Updated dependency constraint to `rag_engine_flutter: ^0.17.0`.
+
 ## 0.16.0
 * **Context**:
   - Improved `ContextBuilder` packing to skip oversized chunks instead of stopping at the first overflow.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_rag_engine
 description: A high-performance, on-device RAG (Retrieval-Augmented Generation) engine for Flutter. Run semantic search completely offline on iOS and Android with HNSW vector indexing.
-version: 0.16.0
+version: 0.17.0
 homepage: https://github.com/dev07060/mobile_rag_engine
 repository: https://github.com/dev07060/mobile_rag_engine
 issue_tracker: https://github.com/dev07060/mobile_rag_engine/issues
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_rust_bridge: ^2.11.1
-  rag_engine_flutter: ^0.16.0
+  rag_engine_flutter: ^0.17.0
   path_provider: ^2.1.5
   onnxruntime: ^1.4.1
   freezed_annotation: ^3.1.0

--- a/rust_builder/CHANGELOG.md
+++ b/rust_builder/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.17.0
+* **Low-level lane**:
+  - Added a generation-pinned `SearchHandle` with metadata-first hybrid search, batch hydration, excerpt fetch, and Rust-side context assembly.
+  - Added bounded `SearchHitMeta` plus `StaleSearchHandle` / `ConcurrentMutation` error paths for low-level handle operations.
+* **Search / Context**:
+  - Added Rust-side context assembly primitives that preserve the current header-path contextual injection and exact engine-tokenizer budgeting contract.
+  - Tightened `SearchHandle` hydration/excerpt/assembly generation checks to reject stale handles and mid-operation mutations deterministically.
+* **Ingest**:
+  - Added UTF-8 bytes and file-based extraction fast paths for additive low-level ingest APIs.
+* **Test**:
+  - Added regression coverage for generation bumps, stale-handle rejection, concurrent mutations during hydration/assembly, duplicate hydration requests, and low-level lane parity.
+
 ## 0.16.0
 * **Chunking**:
   - Hardened plain-text heading detection against short imperative, UI-label, and command-style false positives.

--- a/rust_builder/pubspec.yaml
+++ b/rust_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: rag_engine_flutter
 description: >
   Native Rust FFI plugin for mobile_rag_engine. Provides high-performance
   tokenization and HNSW vector indexing for on-device RAG.
-version: 0.16.0
+version: 0.17.0
 homepage: https://github.com/dev07060/mobile_rag_engine
 repository: https://github.com/dev07060/mobile_rag_engine
 issue_tracker: https://github.com/dev07060/mobile_rag_engine/issues


### PR DESCRIPTION
## Summary

Syncs `main` with the `mobile_rag_engine` and `rag_engine_flutter` **0.17.0** releases that are already published on pub.dev but whose release-prep commit (`c055e1a`) was never merged back to `main`.

- Bumps `mobile_rag_engine` from 0.16.0 → 0.17.0
- Bumps `rag_engine_flutter` from 0.16.0 → 0.17.0
- Updates dependency constraint `rag_engine_flutter: ^0.16.0` → `^0.17.0`
- Adds 0.17.0 CHANGELOG entries for both packages (low-level search lane, UTF-8/file ingest fast paths, stale-handle coverage)

No source code changes — only version metadata and changelogs. This restores parity between `main` and pub.dev before landing 0.18.0 work.

## Test plan

- [ ] Verify `pub.dev/packages/mobile_rag_engine` latest (0.17.0) matches new `pubspec.yaml`
- [ ] Verify `pub.dev/packages/rag_engine_flutter` latest (0.17.0) matches new `rust_builder/pubspec.yaml`
- [ ] `flutter pub get` resolves cleanly with updated constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)