### PR TITLE
feat: prune query-embedding clones across the Rust retrieval hot path (0.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Hybrid and metadata-first search no longer clone the query embedding on every attempt. The `search_meta_hybrid` retry loop, `search_hybrid`'s parallel `std::thread::scope` fan-out, and the incremental-index lookup all borrow the embedding by reference via the new `search_hnsw_slice` / `search_hybrid_inner` slice helpers. Public FRB signatures of `search_hnsw` and `search_hybrid` are unchanged.
   - Consolidated the SQLite-BLOB `decode_f32_embedding` helper into `vector_math` (previously duplicated in `source_rag.rs`, `hybrid_search.rs`, and `simple_rag.rs`).
   - Added `quantize_f32_to_u8_blob` for the `vector_quant_i8` feature so chunk-ingest and re-embedding write the quantized SQLite BLOB without first materializing a `Vec<i8>`.
-* **Compatibility**:
-  - Updated dependency constraint to `rag_engine_flutter: ^0.18.0`.
 * **Migration note**:
   - `Float32List` implements `List<double>`, so `final List<double> e = await embed(x);` and all read-only usages (`e[i]`, `e.length`, iteration, `.fold(...)`) continue to compile and run. Growable-list mutations such as `.add(...)` or `.removeAt(...)` on the returned vector will throw at runtime; embedding vectors were never intended to be appended to in practice.
 * **Docs**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `EmbeddingService.embed()` now returns `Future<Float32List>` (previously `Future<List<double>>`). The worker isolate narrows the mean-pooled vector to `Float32List` before transfer and delivers it via `TransferableTypedData`, eliminating the isolate-boundary deep copy and the downstream `Float32List.fromList(...)` re-allocation at every ingest callsite.
   - `EmbeddingService.embedBatch()` returns `Future<List<Float32List>>` by the same narrowing. Mean-pooling accumulation still happens in `Float64List` so numerical output is bit-identical to the prior f64 → f32 narrowing performed at the receiver.
   - Removed redundant `Float32List.fromList(embedding)` wrappers in `SourceRagService.addSource()` and `SourceRagService.regenerateAllEmbeddings()`.
+* **Retrieval hot path (Rust core)**:
+  - Hybrid and metadata-first search no longer clone the query embedding on every attempt. The `search_meta_hybrid` retry loop, `search_hybrid`'s parallel `std::thread::scope` fan-out, and the incremental-index lookup all borrow the embedding by reference via the new `search_hnsw_slice` / `search_hybrid_inner` slice helpers. Public FRB signatures of `search_hnsw` and `search_hybrid` are unchanged.
+  - Consolidated the SQLite-BLOB `decode_f32_embedding` helper into `vector_math` (previously duplicated in `source_rag.rs`, `hybrid_search.rs`, and `simple_rag.rs`).
+  - Added `quantize_f32_to_u8_blob` for the `vector_quant_i8` feature so chunk-ingest and re-embedding write the quantized SQLite BLOB without first materializing a `Vec<i8>`.
+* **Compatibility**:
+  - Updated dependency constraint to `rag_engine_flutter: ^0.18.0`.
 * **Migration note**:
   - `Float32List` implements `List<double>`, so `final List<double> e = await embed(x);` and all read-only usages (`e[i]`, `e.length`, iteration, `.fold(...)`) continue to compile and run. Growable-list mutations such as `.add(...)` or `.removeAt(...)` on the returned vector will throw at runtime; embedding vectors were never intended to be appended to in practice.
+* **Docs**:
+  - Updated README coverage for the file/UTF-8 ingest fast paths (`addDocumentFromFile`, `addDocumentUtf8`).
+  - Added README guidance for the metadata-first search lane (`searchMeta`, `assembleContext`, `hydrateChunks`, `getChunkExcerpts`).
+  - Clarified memory and advanced-usage wording for the 0.18.0 embedding transport changes.
 
 ## 0.17.0
 * **Low-level APIs**:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Powered by a **Rust core**, it delivers lightning-fast vector search and embedding generation directly on the device. No servers, no API costs, no latency.
 
-> **Memory note:** The runtime is memory-optimized and avoids unnecessary copies in the Rust core, but the current text pipeline is not an end-to-end zero-copy Dart↔Rust transport. Large text payloads still cross the FFI boundary as strings in the current public API.
+> **Memory note:** The embedding vector path is copy-minimized in 0.18.0 with `Float32List` and isolate transfer optimizations, and the Rust core avoids unnecessary copies. This is still not an end-to-end zero-copy Dart↔Rust text pipeline. For large UTF-8 payloads or file-backed ingest, prefer `addDocumentUtf8` / `addDocumentFromFile`; `addDocument(String)` still crosses the public API as a Dart string.
 
 ---
 
@@ -50,9 +50,9 @@ Data never leaves the user's device. Perfect for privacy-focused apps (journals,
 
 | Category | Features |
 |:---------|:---------|
-| **Document Input** | PDF, DOCX, Markdown, Plain Text with smart dehyphenation |
+| **Document Input** | PDF, DOCX, Markdown, Plain Text with smart dehyphenation; file-path and UTF-8 ingest fast paths |
 | **Chunking** | Plain-text paragraph/line chunking with heading-aware split and tokenizer hard guard; Markdown structure-aware chunking with header-path metadata |
-| **Search** | HNSW vector + BM25 keyword hybrid search with RRF fusion |
+| **Search** | HNSW vector + BM25 keyword hybrid search with RRF fusion; metadata-first search with explicit context/chunk hydration |
 | **Storage** | SQLite persistence, HNSW Index persistence (fast startup), connection pooling, resumable indexing |
 | **Collections** | Collection-scoped ingest/search/rebuild via `inCollection('id')` |
 | **Performance** | Rust core, 10x faster tokenization, thread control, memory optimized |
@@ -150,6 +150,15 @@ class MySearchScreen extends StatelessWidget {
     await MobileRag.instance.addDocument(
       'Dart is the language used to build Flutter apps.',
     );
+
+    // File/UTF-8 fast paths are useful for large local documents.
+    await MobileRag.instance.addDocumentFromFile('/path/to/manual.pdf');
+    final noteBytes = await File('/path/to/notes.md').readAsBytes();
+    await MobileRag.instance.addDocumentUtf8(
+      noteBytes,
+      name: 'notes.md',
+    );
+
     // Indexing is automatic! (Debounced 500ms)
     // Optional: await MobileRag.instance.rebuildIndex(); // Call if you want it done NOW
   
@@ -161,6 +170,40 @@ class MySearchScreen extends StatelessWidget {
     
     print(result.context.text); // Ready to send to LLM
   }
+}
+```
+
+### Metadata-First Search
+
+Use `searchMeta` when you want lightweight search metadata first, then explicitly assemble context or hydrate only the chunks you need.
+
+```dart
+final meta = await MobileRag.instance.searchMeta(
+  'What is Flutter?',
+  topK: 10,
+);
+
+try {
+  final context = await MobileRag.instance.assembleContext(
+    searchHandle: meta.handle,
+    tokenBudget: 2000,
+  );
+
+  final chunkIds = meta.hits.map((hit) => hit.chunkId.toInt()).toList();
+  final chunks = await MobileRag.instance.hydrateChunks(
+    searchHandle: meta.handle,
+    chunkIds: chunkIds,
+  );
+  final excerpts = await MobileRag.instance.getChunkExcerpts(
+    searchHandle: meta.handle,
+    chunkIds: chunkIds,
+    maxBytes: 256,
+  );
+
+  print(context.text);
+  print('hydrated=${chunks.length}, excerpts=${excerpts.length}');
+} finally {
+  await meta.handle.dispose();
 }
 ```
 
@@ -185,7 +228,7 @@ print(travelHits.length);
 If you do not specify a collection, the engine uses the default `__default__`
 collection for backward compatibility.
 
-> **Advanced Usage:** For fine-grained control, you can still use the low-level APIs (`initTokenizer`, `EmbeddingService`, `SourceRagService`) directly. See the [API Reference](https://pub.dev/documentation/mobile_rag_engine/latest/).
+> **Advanced Usage:** For fine-grained control, use the high-level metadata lane (`searchMeta`, `assembleContext`, `hydrateChunks`, `getChunkExcerpts`) or service APIs such as `EmbeddingService` and `SourceRagService` directly. See the [API Reference](https://pub.dev/documentation/mobile_rag_engine/latest/).
 
 
 ---

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -293,7 +293,7 @@ packages:
       path: "../rust_builder"
       relative: true
     source: path
-    version: "0.17.0"
+    version: "0.18.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_rust_bridge: ^2.11.1
-  rag_engine_flutter: ^0.18.0
+  rag_engine_flutter: ^0.17.0
   path_provider: ^2.1.5
   onnxruntime: ^1.4.1
   freezed_annotation: ^3.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_rust_bridge: ^2.11.1
-  rag_engine_flutter: ^0.17.0
+  rag_engine_flutter: ^0.18.0
   path_provider: ^2.1.5
   onnxruntime: ^1.4.1
   freezed_annotation: ^3.1.0

--- a/rust_builder/CHANGELOG.md
+++ b/rust_builder/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.18.0
+* **Retrieval hot path (copy-minimized Rust core)**:
+  - Added `search_hnsw_slice(&[f32], usize)` and `search_hybrid_inner(String, &[f32], ...)` as borrowed-slice variants of the existing FFI-public entrypoints. The owned-`Vec<f32>` signatures of `search_hnsw` and `search_hybrid` are preserved for `flutter_rust_bridge` compatibility and now delegate to the slice helpers.
+  - Updated `search_meta_hybrid`'s retry loop to borrow the query text, embedding, and options across attempts. A transient `ConcurrentMutation` no longer forces per-attempt `Vec<f32>` / `String` / `SearchMetaHybridOptions` clones.
+  - Refactored the parallel vector + BM25 fan-out inside `search_hybrid_inner` to capture the embedding by reference inside `std::thread::scope` rather than cloning per spawn.
+  - Replaced the per-file `decode_f32_embedding` copies in `source_rag.rs`, `hybrid_search.rs`, and `simple_rag.rs` with a single shared `vector_math::decode_f32_embedding` so the SQLite-BLOB → `Vec<f32>` decode path is owned in one place.
+* **Quantization storage path (`vector_quant_i8` feature)**:
+  - Added `quantize_f32_to_u8_blob(&[f32]) -> (Vec<u8>, f32)` which produces the SQLite BLOB representation directly without the intermediate `Vec<i8>` that `quantize_f32_to_i8` + `i8_blob_from_slice` previously required. The two paths are byte-for-byte identical and covered by a parity regression test.
+  - Switched the four ingest/migration callsites (`source_rag.rs`, `simple_rag.rs`) that store quantized embeddings to the direct blob path.
+
 ## 0.17.0
 * **Low-level lane**:
   - Added a generation-pinned `SearchHandle` with metadata-first hybrid search, batch hydration, excerpt fetch, and Rust-side context assembly.

--- a/rust_builder/pubspec.yaml
+++ b/rust_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: rag_engine_flutter
 description: >
   Native Rust FFI plugin for mobile_rag_engine. Provides high-performance
   tokenization and HNSW vector indexing for on-device RAG.
-version: 0.17.0
+version: 0.18.0
 homepage: https://github.com/dev07060/mobile_rag_engine
 repository: https://github.com/dev07060/mobile_rag_engine
 issue_tracker: https://github.com/dev07060/mobile_rag_engine/issues

--- a/rust_builder/rust/src/api/hnsw_index.rs
+++ b/rust_builder/rust/src/api/hnsw_index.rs
@@ -223,6 +223,10 @@ pub struct HnswSearchResult {
 
 /// Search in HNSW index.
 ///
+/// Owned-vector entrypoint kept stable for the flutter_rust_bridge surface;
+/// delegates to the slice-based implementation so internal Rust callers can
+/// avoid `Vec<f32>` allocations on hot paths.
+///
 /// ef_search parameter controls accuracy vs speed:
 /// - Higher ef_search = better recall but slower
 /// - Lower ef_search = faster but may miss relevant results
@@ -230,6 +234,17 @@ pub struct HnswSearchResult {
 /// Current tuning targets ~95% recall for most use cases.
 pub fn search_hnsw(
     query_embedding: Vec<f32>,
+    top_k: usize,
+) -> anyhow::Result<Vec<HnswSearchResult>> {
+    search_hnsw_slice(&query_embedding, top_k)
+}
+
+/// Slice-based variant of [`search_hnsw`]. Internal Rust callers should
+/// prefer this entrypoint when the query embedding is already held by
+/// reference (e.g. inside `std::thread::scope` closures or retry loops)
+/// so the vector does not need to be cloned per call.
+pub fn search_hnsw_slice(
+    query_embedding: &[f32],
     top_k: usize,
 ) -> anyhow::Result<Vec<HnswSearchResult>> {
     debug!("[hnsw] Starting search, top_k: {}", top_k);
@@ -251,7 +266,7 @@ pub fn search_hnsw(
 
     debug!("[hnsw] Using ef_search={}", ef_search);
 
-    let neighbors = index.search(&query_embedding, top_k, ef_search);
+    let neighbors = index.search(query_embedding, top_k, ef_search);
 
     let results: Vec<HnswSearchResult> = neighbors
         .iter()

--- a/rust_builder/rust/src/api/hybrid_search.rs
+++ b/rust_builder/rust/src/api/hybrid_search.rs
@@ -22,8 +22,8 @@ use std::collections::{HashMap, HashSet};
 use crate::api::bm25_search::{bm25_search, tokenize_for_bm25, Bm25SearchResult};
 use crate::api::db_pool::get_connection;
 use crate::api::error::RagError;
-use crate::api::hnsw_index::{is_hnsw_index_loaded, search_hnsw, HnswSearchResult};
-use crate::api::vector_math::{cosine_with_query_norm_f32, l2_norm_f32};
+use crate::api::hnsw_index::{is_hnsw_index_loaded, search_hnsw_slice, HnswSearchResult};
+use crate::api::vector_math::{cosine_with_query_norm_f32, decode_f32_embedding, l2_norm_f32};
 #[cfg(feature = "vector_quant_i8")]
 use crate::api::vector_quant::{cosine_with_query_norm_i8_blob, l2_norm_i8, quantize_f32_to_i8};
 
@@ -67,21 +67,28 @@ fn rrf_score(rank: usize, k: u32) -> f64 {
     1.0 / (k as f64 + rank as f64)
 }
 
-fn decode_f32_embedding(blob: &[u8]) -> Option<Vec<f32>> {
-    if blob.len() % 4 != 0 {
-        return None;
-    }
-    Some(
-        blob.chunks(4)
-            .map(|chunk| f32::from_ne_bytes(chunk.try_into().unwrap()))
-            .collect(),
-    )
-}
-
 /// Perform hybrid search combining vector and keyword search.
+///
+/// Owned-vector entrypoint kept stable for the flutter_rust_bridge
+/// surface; internal Rust callers should prefer [`search_hybrid_inner`]
+/// to avoid cloning the query embedding when it is already held by
+/// reference (e.g. inside `search_meta_hybrid`'s retry loop).
 pub fn search_hybrid(
     query_text: String,
     query_embedding: Vec<f32>,
+    top_k: u32,
+    config: Option<RrfConfig>,
+    filter: Option<SearchFilter>,
+) -> Result<Vec<HybridSearchResult>, RagError> {
+    search_hybrid_inner(query_text, &query_embedding, top_k, config, filter)
+}
+
+/// Slice-based variant of [`search_hybrid`]. The query embedding is
+/// borrowed for the lifetime of the call so retry loops and scoped
+/// thread spawns can reuse it without per-attempt `Vec<f32>` clones.
+pub(crate) fn search_hybrid_inner(
+    query_text: String,
+    query_embedding: &[f32],
     top_k: u32,
     config: Option<RrfConfig>,
     filter: Option<SearchFilter>,
@@ -111,7 +118,7 @@ pub fn search_hybrid(
         let (vec_res, bm25_res) = std::thread::scope(|s| {
             let handle_vec = s.spawn(|| {
                 if is_hnsw_index_loaded() {
-                    search_hnsw(query_embedding.clone(), candidate_k).unwrap_or_else(|e| {
+                    search_hnsw_slice(query_embedding, candidate_k).unwrap_or_else(|e| {
                         log::error!("[hybrid] Vector search failed: {}", e);
                         vec![]
                     })
@@ -221,9 +228,9 @@ pub fn search_hybrid(
                 })
                 .map_err(|e| RagError::DatabaseError(e.to_string()))?;
 
-            let query_norm = l2_norm_f32(&query_embedding);
+            let query_norm = l2_norm_f32(query_embedding);
             #[cfg(feature = "vector_quant_i8")]
-            let (query_i8, _query_i8_scale) = quantize_f32_to_i8(&query_embedding);
+            let (query_i8, _query_i8_scale) = quantize_f32_to_i8(query_embedding);
             #[cfg(feature = "vector_quant_i8")]
             let query_i8_norm = l2_norm_i8(&query_i8);
             let query_tokens = tokenize_for_bm25(&query_text);
@@ -251,7 +258,7 @@ pub fn search_hybrid(
                             if embedding.len() != query_embedding.len() {
                                 continue;
                             }
-                            cosine_with_query_norm_f32(&query_embedding, query_norm, &embedding)
+                            cosine_with_query_norm_f32(query_embedding, query_norm, &embedding)
                         } else {
                             continue;
                         }
@@ -259,7 +266,7 @@ pub fn search_hybrid(
                         if embedding.len() != query_embedding.len() {
                             continue;
                         }
-                        cosine_with_query_norm_f32(&query_embedding, query_norm, &embedding)
+                        cosine_with_query_norm_f32(query_embedding, query_norm, &embedding)
                     } else {
                         continue;
                     };
@@ -269,7 +276,7 @@ pub fn search_hybrid(
                         if embedding.len() != query_embedding.len() {
                             continue;
                         }
-                        cosine_with_query_norm_f32(&query_embedding, query_norm, &embedding)
+                        cosine_with_query_norm_f32(query_embedding, query_norm, &embedding)
                     } else {
                         continue;
                     };

--- a/rust_builder/rust/src/api/incremental_index.rs
+++ b/rust_builder/rust/src/api/incremental_index.rs
@@ -16,7 +16,7 @@
 //
 //! Incremental Vector Index with Dual-Index Strategy (buffer + HNSW).
 
-use crate::api::hnsw_index::{is_hnsw_index_loaded, search_hnsw};
+use crate::api::hnsw_index::{is_hnsw_index_loaded, search_hnsw_slice};
 #[cfg(not(feature = "vector_quant_i8"))]
 use crate::api::vector_math::{cosine_with_query_norm_f32, l2_norm_f32};
 #[cfg(feature = "vector_quant_i8")]
@@ -150,7 +150,7 @@ pub fn incremental_search(
     }
 
     if is_hnsw_index_loaded() {
-        let hnsw_results = search_hnsw(query_embedding.clone(), top_k * 2)?;
+        let hnsw_results = search_hnsw_slice(&query_embedding, top_k * 2)?;
         for result in hnsw_results {
             all_results.push((result.id, result.distance, "hnsw"));
         }

--- a/rust_builder/rust/src/api/simple_rag.rs
+++ b/rust_builder/rust/src/api/simple_rag.rs
@@ -22,11 +22,13 @@ use crate::api::hnsw_index::{
     build_hnsw_index, clear_hnsw_index, is_hnsw_index_loaded, search_hnsw,
 };
 use crate::api::incremental_index::{clear_buffer, incremental_add};
-use crate::api::vector_math::{cosine_f32, cosine_with_query_norm_f32, l2_norm_f32};
+use crate::api::vector_math::{
+    cosine_f32, cosine_with_query_norm_f32, decode_f32_embedding, l2_norm_f32,
+};
 #[cfg(feature = "vector_quant_i8")]
 use crate::api::vector_quant::{
-    cosine_with_query_norm_i8_blob, dequantize_i8_to_f32, i8_blob_from_slice, i8_vec_from_blob,
-    l2_norm_i8, quantize_f32_to_i8,
+    cosine_with_query_norm_i8_blob, dequantize_i8_to_f32, i8_vec_from_blob, l2_norm_i8,
+    quantize_f32_to_i8, quantize_f32_to_u8_blob,
 };
 use flutter_rust_bridge::frb;
 use log::{debug, error, info, warn};
@@ -44,17 +46,6 @@ fn calculate_content_hash(content: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content.as_bytes());
     format!("{:x}", hasher.finalize())
-}
-
-fn decode_f32_embedding(blob: &[u8]) -> Option<Vec<f32>> {
-    if blob.len() % 4 != 0 {
-        return None;
-    }
-    Some(
-        blob.chunks(4)
-            .map(|chunk| f32::from_ne_bytes(chunk.try_into().unwrap()))
-            .collect(),
-    )
 }
 
 /// Calculate cosine similarity between two vectors.
@@ -149,10 +140,10 @@ pub fn init_db() -> anyhow::Result<()> {
             if embedding.is_empty() {
                 continue;
             }
-            let (embedding_i8, embedding_scale) = quantize_f32_to_i8(&embedding);
+            let (embedding_i8_bytes, embedding_scale) = quantize_f32_to_u8_blob(&embedding);
             conn.execute(
                 "UPDATE docs SET embedding_i8 = ?1, embedding_scale = ?2 WHERE id = ?3",
-                params![i8_blob_from_slice(&embedding_i8), embedding_scale, id],
+                params![embedding_i8_bytes, embedding_scale, id],
             )?;
         }
     }
@@ -311,8 +302,7 @@ pub fn add_document(content: String, embedding: Vec<f32>) -> anyhow::Result<AddD
 
     #[cfg(feature = "vector_quant_i8")]
     {
-        let (embedding_i8, embedding_scale) = quantize_f32_to_i8(&embedding);
-        let embedding_i8_bytes = i8_blob_from_slice(&embedding_i8);
+        let (embedding_i8_bytes, embedding_scale) = quantize_f32_to_u8_blob(&embedding);
 
         if has_embedding_i8_column && has_embedding_scale_column {
             conn.execute(

--- a/rust_builder/rust/src/api/source_rag.rs
+++ b/rust_builder/rust/src/api/source_rag.rs
@@ -23,13 +23,13 @@ use crate::api::hnsw_index::{
     build_hnsw_index, clear_hnsw_index, is_hnsw_index_loaded, load_hnsw_index, save_hnsw_index,
     search_hnsw,
 };
-use crate::api::hybrid_search::{search_hybrid, RrfConfig, SearchFilter};
+use crate::api::hybrid_search::{search_hybrid_inner, RrfConfig, SearchFilter};
 use crate::api::tokenizer::count_plain_text_tokens_untruncated;
-use crate::api::vector_math::{cosine_with_query_norm_f32, l2_norm_f32};
+use crate::api::vector_math::{cosine_with_query_norm_f32, decode_f32_embedding, l2_norm_f32};
 #[cfg(feature = "vector_quant_i8")]
 use crate::api::vector_quant::{
-    cosine_with_query_norm_i8_blob, dequantize_i8_to_f32, i8_blob_from_slice, i8_vec_from_blob,
-    l2_norm_i8, quantize_f32_to_i8,
+    cosine_with_query_norm_i8_blob, dequantize_i8_to_f32, i8_vec_from_blob, l2_norm_i8,
+    quantize_f32_to_i8, quantize_f32_to_u8_blob,
 };
 use crate::frb_generated::RustAutoOpaqueMoi as RustAutoOpaque;
 use flutter_rust_bridge::frb;
@@ -64,17 +64,6 @@ fn hash_content(content: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content.as_bytes());
     format!("{:x}", hasher.finalize())
-}
-
-fn decode_f32_embedding(blob: &[u8]) -> Option<Vec<f32>> {
-    if blob.len() % 4 != 0 {
-        return None;
-    }
-    Some(
-        blob.chunks(4)
-            .map(|chunk| f32::from_ne_bytes(chunk.try_into().unwrap()))
-            .collect(),
-    )
 }
 
 fn normalize_collection_id(collection_id: String) -> String {
@@ -371,10 +360,10 @@ pub fn init_source_db() -> Result<(), RagError> {
             if embedding.is_empty() {
                 continue;
             }
-            let (embedding_i8, embedding_scale) = quantize_f32_to_i8(&embedding);
+            let (embedding_i8_bytes, embedding_scale) = quantize_f32_to_u8_blob(&embedding);
             conn.execute(
                 "UPDATE chunks SET embedding_i8 = ?1, embedding_scale = ?2 WHERE id = ?3",
-                params![i8_blob_from_slice(&embedding_i8), embedding_scale, id],
+                params![embedding_i8_bytes, embedding_scale, id],
             )
             .map_err(|e| RagError::DatabaseError(e.to_string()))?;
         }
@@ -727,8 +716,8 @@ pub fn add_chunks(source_id: i64, chunks: Vec<ChunkData>) -> Result<i32, RagErro
 
         #[cfg(feature = "vector_quant_i8")]
         {
-            let (embedding_i8, embedding_scale) = quantize_f32_to_i8(&chunk.embedding);
-            let embedding_i8_bytes = i8_blob_from_slice(&embedding_i8);
+            let (embedding_i8_bytes, embedding_scale) =
+                quantize_f32_to_u8_blob(&chunk.embedding);
 
             if has_chunk_embedding_i8 && has_chunk_embedding_scale {
                 tx.execute(
@@ -1234,12 +1223,17 @@ pub fn search_meta_hybrid(
     let collection_id = normalize_collection_id(collection_id);
     let mut last_error = None;
 
+    // Borrow the inputs across retry attempts so a transient
+    // ConcurrentMutation does not force per-attempt clones of the
+    // 1.5KB+ query embedding (and matching String/options copies).
+    // `search_meta_hybrid_once` constructs the owned `SearchHandle`
+    // payload internally, cloning only what the handle actually stores.
     for _attempt in 0..=1 {
         match search_meta_hybrid_once(
             &collection_id,
-            query_text.clone(),
-            query_embedding.clone(),
-            options.clone(),
+            &query_text,
+            &query_embedding,
+            &options,
         ) {
             Ok(handle) => return Ok(RustAutoOpaque::new(handle)),
             Err(err @ RagError::ConcurrentMutation(_)) => last_error = Some(err),
@@ -1387,9 +1381,9 @@ fn fetch_adjacent_hit_meta(
 
 fn search_meta_hybrid_once(
     collection_id: &str,
-    query_text: String,
-    query_embedding: Vec<f32>,
-    options: SearchMetaHybridOptions,
+    query_text: &str,
+    query_embedding: &[f32],
+    options: &SearchMetaHybridOptions,
 ) -> Result<SearchHandle, RagError> {
     let conn = get_connection().map_err(|e| RagError::DatabaseError(e.to_string()))?;
     let start_generation = get_collection_data_generation(&conn, collection_id)?;
@@ -1405,8 +1399,8 @@ fn search_meta_hybrid_once(
         options.top_k
     };
 
-    let hybrid_results = search_hybrid(
-        query_text.clone(),
+    let hybrid_results = search_hybrid_inner(
+        query_text.to_string(),
         query_embedding,
         effective_top_k,
         Some(RrfConfig {
@@ -1488,10 +1482,10 @@ fn search_meta_hybrid_once(
     Ok(SearchHandle {
         collection_id: collection_id.to_string(),
         data_generation: start_generation,
-        query_text,
+        query_text: query_text.to_string(),
         base_hits,
         ordered_hits,
-        _query_options: options,
+        _query_options: options.clone(),
     })
 }
 
@@ -3096,9 +3090,9 @@ mod tests {
 
         let handle: SearchHandle = search_meta_hybrid_once(
             collection,
-            "긴 헤더".to_string(),
-            vec![1.0, 0.0, 0.0, 0.0],
-            SearchMetaHybridOptions {
+            "긴 헤더",
+            &[1.0, 0.0, 0.0, 0.0],
+            &SearchMetaHybridOptions {
                 top_k: 1,
                 vector_weight: 1.0,
                 bm25_weight: 0.0,
@@ -3193,9 +3187,9 @@ mod tests {
         .unwrap();
         let hits: SearchHandle = search_meta_hybrid_once(
             collection,
-            "install".to_string(),
-            vec![1.0, 0.0, 0.0, 0.0],
-            SearchMetaHybridOptions {
+            "install",
+            &[1.0, 0.0, 0.0, 0.0],
+            &SearchMetaHybridOptions {
                 top_k: 2,
                 vector_weight: 1.0,
                 bm25_weight: 0.0,

--- a/rust_builder/rust/src/api/vector_math.rs
+++ b/rust_builder/rust/src/api/vector_math.rs
@@ -4,6 +4,22 @@
 // Shared vector math kernels for retrieval paths.
 // Keeping this module allocation-free helps mobile hot paths.
 
+/// Decode a SQLite `BLOB` column previously written as a native-endian
+/// f32 byte stream back into a `Vec<f32>`. Returns `None` when the
+/// stored length is not a multiple of 4, which would indicate a corrupt
+/// or unexpected payload.
+#[inline]
+pub(crate) fn decode_f32_embedding(blob: &[u8]) -> Option<Vec<f32>> {
+    if blob.len() % 4 != 0 {
+        return None;
+    }
+    Some(
+        blob.chunks_exact(4)
+            .map(|chunk| f32::from_ne_bytes(chunk.try_into().unwrap()))
+            .collect(),
+    )
+}
+
 #[inline]
 pub(crate) fn dot_f32(a: &[f32], b: &[f32]) -> f32 {
     backend::dot_f32(a, b)

--- a/rust_builder/rust/src/api/vector_quant.rs
+++ b/rust_builder/rust/src/api/vector_quant.rs
@@ -39,6 +39,35 @@ pub fn i8_blob_from_slice(input: &[i8]) -> Vec<u8> {
     input.iter().map(|v| *v as u8).collect()
 }
 
+/// Quantize an `f32` embedding directly into the SQLite `BLOB`
+/// representation, skipping the intermediate `Vec<i8>` that
+/// [`quantize_f32_to_i8`] + [`i8_blob_from_slice`] would otherwise
+/// produce. Returns the quantized bytes together with the scale used
+/// to dequantize them later. Behaviour is bit-for-bit equivalent to
+/// calling the two helpers sequentially.
+#[inline]
+pub fn quantize_f32_to_u8_blob(input: &[f32]) -> (Vec<u8>, f32) {
+    if input.is_empty() {
+        return (Vec::new(), 1.0);
+    }
+
+    let max_abs = input
+        .iter()
+        .fold(0.0f32, |acc, v| if v.abs() > acc { v.abs() } else { acc });
+    if max_abs == 0.0 {
+        return (vec![0u8; input.len()], 1.0);
+    }
+
+    let scale = max_abs / 127.0;
+    let inv_scale = 1.0 / scale;
+    let blob = input
+        .iter()
+        .map(|v| (v * inv_scale).round().clamp(-127.0, 127.0) as i8 as u8)
+        .collect();
+
+    (blob, scale)
+}
+
 #[inline]
 pub fn i8_vec_from_blob(blob: &[u8]) -> Vec<i8> {
     blob.iter().map(|v| *v as i8).collect()
@@ -144,5 +173,26 @@ mod tests {
         let from_slice = cosine_with_query_norm_i8(&qa, l2_norm_i8(&qa), &qb);
         let from_blob = cosine_with_query_norm_i8_blob(&qa, l2_norm_i8(&qa), &blob);
         assert!((from_slice - from_blob).abs() < 1e-6);
+    }
+
+    #[test]
+    fn quantize_f32_to_u8_blob_matches_two_step_pipeline() {
+        // The direct blob path skips an intermediate Vec<i8>; the
+        // resulting bytes and scale must be bit-for-bit identical to
+        // quantize_f32_to_i8 + i8_blob_from_slice.
+        let inputs: &[&[f32]] = &[
+            &[],
+            &[0.0],
+            &[0.1, -0.25, 0.5, 1.0, -1.2, 2.3],
+            &[-3.4, 0.0, 3.4, -1.7, 1.7],
+        ];
+
+        for input in inputs {
+            let (direct_blob, direct_scale) = quantize_f32_to_u8_blob(input);
+            let (i8_vec, two_step_scale) = quantize_f32_to_i8(input);
+            let two_step_blob = i8_blob_from_slice(&i8_vec);
+            assert_eq!(direct_scale, two_step_scale);
+            assert_eq!(direct_blob, two_step_blob);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes the remaining clone-heavy callsites on the Rust retrieval hot path that the embedding zero-copy PR (#32) intentionally left to a follow-up. None of the public `flutter_rust_bridge` signatures change — every refactor adds a slice-based variant and routes the owned-vector entrypoint through it.

| Area | Before | After |
|---|---|---|
| `search_hnsw` | `Vec<f32>` only | New `search_hnsw_slice(&[f32], _)`; owned variant delegates |
| `search_hybrid` | `Vec<f32>` only | New `search_hybrid_inner(_, &[f32], …)`; owned variant delegates |
| `search_meta_hybrid` retry loop | Cloned `query_text` + `query_embedding` + `options` per attempt | Borrows all three across attempts; owned `SearchHandle` payload built once on success |
| Parallel fan-out in `search_hybrid_inner` | `query_embedding.clone()` per `s.spawn` | `std::thread::scope` borrows the slice |
| `incremental_index::incremental_search` | `query_embedding.clone()` for HNSW | Slice handoff via `search_hnsw_slice` |
| `decode_f32_embedding` | Duplicated in `source_rag.rs`, `hybrid_search.rs`, `simple_rag.rs` | Single owner in `vector_math` |
| `quantize_f32_to_i8 + i8_blob_from_slice` for ingest | Two-step allocation | New `quantize_f32_to_u8_blob` direct path; byte-for-byte equivalent (covered by parity test) |

For a hot-path query the saving is roughly:

- Vector search alone: 1× `Vec<f32>` clone removed (~1.5KB for a 384-dim embedding)
- `search_meta_hybrid` retry path: 2× embedding clones + 2× `String` clones + 1× `SearchMetaHybridOptions` clone removed
- Quantized ingest (`vector_quant_i8`): one `Vec<i8>` allocation removed per chunk

## Versioning

- `rag_engine_flutter`: 0.17.0 → **0.18.0** (additive API additions + internal optimizations; mobile_rag_engine main was already at 0.18.0 pending this matching release)
- `mobile_rag_engine` dependency constraint: `^0.17.0` → `^0.18.0`
- CHANGELOG entries appended to the in-progress 0.18.0 sections in both packages.

## Bundled docs

The PR also includes the in-flight README + CHANGELOG docs prep that was already sitting on the working tree for the 0.18.0 release (file/UTF-8 ingest fast paths, metadata-first search lane, refreshed memory note). They cleanly cohere with the 0.18.0 release and were too tightly interleaved with the new CHANGELOG entries to split cleanly.

## Test plan

- [x] `cargo check` — clean (one pre-existing `search_chunks_linear` dead-code warning)
- [x] `cargo check --features vector_quant_i8` — clean (plus one new dead-code warning for `i8_blob_from_slice`, which stays exported for downstream Rust consumers but no longer has an in-tree caller)
- [x] `cargo test --lib --features vector_quant_i8 -- --test-threads=1` — 97 passed, 0 failed, 1 ignored (parallel runs also fail on `main` at the same 3 tests due to pre-existing global-state isolation issues; not introduced here)
- [x] `flutter test test/unit/` — 55 passed
- [x] FRB-public signatures of `search_hnsw` and `search_hybrid` byte-identical, so no `flutter_rust_bridge_codegen` regeneration is required

