### PR TITLE
chore: bump rag_engine_flutter constraint to ^0.18.0 (0.18.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.18.1
+* **Compatibility**:
+  - Bumped dependency constraint to `rag_engine_flutter: ^0.18.0` so consumers actually receive the matching native release with the 0.18.0 retrieval hot-path optimizations. The 0.18.0 publish shipped with the prior `^0.17.0` constraint by mistake and resolved to `rag_engine_flutter 0.17.0` for new installs.
+
 ## 0.18.0
 * **Embedding path (zero-copy transport)**:
   - `EmbeddingService.embed()` now returns `Future<Float32List>` (previously `Future<List<double>>`). The worker isolate narrows the mean-pooled vector to `Float32List` before transfer and delivers it via `TransferableTypedData`, eliminating the isolate-boundary deep copy and the downstream `Float32List.fromList(...)` re-allocation at every ingest callsite.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -206,7 +206,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.18.0"
+    version: "0.18.1"
   onnxruntime:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -479,10 +479,10 @@ packages:
     dependency: "direct main"
     description:
       name: rag_engine_flutter
-      sha256: "778924147e5aa7abb14524f619334c2e9e33fa452064434b93a9b7cf5b62ff28"
+      sha256: "48d87a6dd53842fb4c58fe34efda5089e84dcdbbff3b2fd49f68bfe9253611d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.0"
+    version: "0.18.0"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_rag_engine
 description: A high-performance, on-device RAG (Retrieval-Augmented Generation) engine for Flutter. Run semantic search completely offline on iOS and Android with HNSW vector indexing.
-version: 0.18.0
+version: 0.18.1
 homepage: https://github.com/dev07060/mobile_rag_engine
 repository: https://github.com/dev07060/mobile_rag_engine
 issue_tracker: https://github.com/dev07060/mobile_rag_engine/issues
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_rust_bridge: ^2.11.1
-  rag_engine_flutter: ^0.17.0
+  rag_engine_flutter: ^0.18.0
   path_provider: ^2.1.5
   onnxruntime: ^1.4.1
   freezed_annotation: ^3.1.0


### PR DESCRIPTION
## Summary

- Follow-up to e39dcff which intentionally kept the constraint at `^0.17.0` to unblock CI before `rag_engine_flutter 0.18.0` was published.
- The native package has since been published to pub.dev, so consumers can now resolve against the matching 0.18.0 native release with the retrieval hot-path optimizations from PR #33.
- Bumps `mobile_rag_engine` to `0.18.1` since 0.18.0 shipped with the prior `^0.17.0` constraint and would have resolved to `rag_engine_flutter 0.17.0` for new installs.

## Changes

- `pubspec.yaml`: `version: 0.18.0 → 0.18.1`, `rag_engine_flutter: ^0.17.0 → ^0.18.0`
- `pubspec.lock`: refreshed against published `rag_engine_flutter 0.18.0`
- `example/pubspec.lock`: path-source `mobile_rag_engine` bumped to 0.18.1
- `CHANGELOG.md`: 0.18.1 entry describing the lockstep correction

## Test plan

- [x] `flutter pub get` resolves cleanly with new constraint
- [ ] CI green on this PR (now that `rag_engine_flutter 0.18.0` is live on pub.dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)