### PR TITLE
feat: ingest from_utf8 / from_file true bytes pass-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 
 Powered by a **Rust core**, it delivers lightning-fast vector search and embedding generation directly on the device. No servers, no API costs, no latency.
 
-> **Memory note:** The embedding vector path is copy-minimized in 0.18.0 with `Float32List` and isolate transfer optimizations, and the Rust core avoids unnecessary copies. The ingest text pipeline now keeps chunk content resident in Rust between chunking and DB commit — one `addDocument(content)` call sends the document body across FFI **~2× document size** (down from ~4× under the pre-IngestSession chain). Verified by `BenchmarkService.benchmarkIngestFfiTraffic` and `test/native/ingest_ffi_traffic_test.dart`: 256 KB doc → legacy 1019 KB / IngestSession 510 KB / 50% reduction. Public `addDocument(String)` signature is unchanged.
+> **Memory note:** The embedding vector path is copy-minimized in 0.18.0 with `Float32List` and isolate transfer optimizations, and the Rust core avoids unnecessary copies. The ingest text pipeline now keeps chunk content resident in Rust between chunking and DB commit — one `addDocument(content)` call sends the document body across FFI **~2× document size** (down from ~4× under the pre-IngestSession chain). Verified by `BenchmarkService.benchmarkIngestFfiTraffic` and `test/native/ingest_ffi_traffic_test.dart`: 256 KB doc → legacy 1019 KB / IngestSession 510 KB / 50% reduction.
+>
+> `addDocumentUtf8(bytes)` and `addDocumentFromFile(path)` are now true Rust-side bytes pass-through entrypoints (Rust functions `prepareSourceIngestionFromUtf8` / `prepareSourceIngestionFromFile`): UTF-8 bytes go straight into Rust without an intermediate Dart `String` (saves the Dart-heap UTF-16 inflation — ~8 MB for a 4 MB file), and the file variant reads the body inside Rust so it **never crosses FFI at all**. Lock-in test `test/native/ingest_ffi_traffic_test.dart` measures (256 KB doc): String 256.1 KB / UTF-8 256.1 KB / File **0.0 KB** of `session_prepare_content_in_bytes`. Public `addDocument(String)`, `addDocumentUtf8(bytes)`, and `addDocumentFromFile(path)` signatures are unchanged.
 
 ---
 

--- a/lib/services/benchmark_service.dart
+++ b/lib/services/benchmark_service.dart
@@ -515,6 +515,145 @@ class BenchmarkService {
     );
   }
 
+  /// Measure FFI text-byte traffic across the three IngestSession entrypoints
+  /// on a deterministic document: the canonical `prepareSourceIngestion`
+  /// (Dart String), `prepareSourceIngestionFromUtf8` (bytes), and
+  /// `prepareSourceIngestionFromFile` (path-only). Stub embeddings keep the
+  /// measurement focused on FFI byte traffic.
+  ///
+  /// The body bytes never round-trip back through Dart on the file variant,
+  /// so `session_prepare_content_in_bytes` should be 0 for it.
+  static Future<IngestFfiEntrypointBenchResult>
+      benchmarkIngestFfiEntrypoints({
+    int targetBytes = 1 * 1024 * 1024,
+    int embeddingDim = 384,
+    int maxChunkChars = 1500,
+    int overlapChars = 100,
+    int batchSize = 16,
+    String? restoreDbPath,
+    String? dbPathOverride,
+  }) async {
+    final content = _generateBenchDoc(targetBytes);
+    // ASCII-only doc: String length == UTF-8 byte count.
+    final docUtf8Bytes = content.length;
+
+    final benchDbPath = dbPathOverride ??
+        "${(await getApplicationDocumentsDirectory()).path}/ingest_ffi_entrypoints_bench.sqlite";
+    final benchFile = File(benchDbPath);
+    if (await benchFile.exists()) {
+      await benchFile.delete();
+    }
+    final benchTextFile = File('$benchDbPath.txt');
+    if (await benchTextFile.exists()) {
+      await benchTextFile.delete();
+    }
+    await benchTextFile.writeAsString(content, flush: true);
+
+    await initDbPool(dbPath: benchDbPath, maxSize: 4);
+    await initDb();
+    await source_rag.initSourceDb();
+
+    final stubEmbedding = Float32List(embeddingDim);
+
+    Future<ingest_metrics.IngestTrafficStats> runOne(
+      Future<ingest_session.PreparedIngestion> Function() prepare,
+      String collectionId,
+    ) async {
+      ingest_metrics.resetIngestTrafficStats();
+      final prepared = await prepare();
+      final session = prepared.session;
+      if (session == null) {
+        throw StateError(
+          'benchmarkIngestFfiEntrypoints: prepare returned no session '
+          '(state=${prepared.state}); benchmark requires a fresh collection.',
+        );
+      }
+      try {
+        var saved = 0;
+        while (saved < prepared.totalChunks) {
+          final batch = await session.takeEmbeddingBatch(batchSize: batchSize);
+          if (batch.isEmpty) break;
+          final embeddings = batch
+              .map(
+                (req) => ingest_session.ChunkEmbedding(
+                  chunkIndex: req.chunkIndex,
+                  embedding: stubEmbedding,
+                ),
+              )
+              .toList(growable: false);
+          saved += await session.commitEmbeddings(embeddings: embeddings);
+        }
+        await session.finalize();
+      } finally {
+        await session.dispose();
+      }
+      final stats = ingest_metrics.ingestTrafficStats();
+      await source_rag.deleteSourceInCollection(
+        collectionId: collectionId,
+        sourceId: prepared.sourceId,
+      );
+      return stats;
+    }
+
+    final stringStats = await runOne(
+      () => ingest_session.prepareSourceIngestion(
+        collectionId: 'bench-string',
+        content: content,
+        metadata: null,
+        name: 'bench-string',
+        strategy: ingest_session.IngestStrategy.recursive,
+        maxChars: maxChunkChars,
+        overlapChars: overlapChars,
+      ),
+      'bench-string',
+    );
+
+    final utf8Bytes = Uint8List.fromList(content.codeUnits);
+    final utf8Stats = await runOne(
+      () => ingest_session.prepareSourceIngestionFromUtf8(
+        collectionId: 'bench-utf8',
+        contentBytes: utf8Bytes,
+        metadata: null,
+        name: 'bench-utf8',
+        strategy: ingest_session.IngestStrategy.recursive,
+        maxChars: maxChunkChars,
+        overlapChars: overlapChars,
+      ),
+      'bench-utf8',
+    );
+
+    final fileStats = await runOne(
+      () => ingest_session.prepareSourceIngestionFromFile(
+        collectionId: 'bench-file',
+        filePath: benchTextFile.path,
+        metadata: null,
+        name: 'bench-file',
+        strategyHint: ingest_session.IngestStrategy.recursive,
+        maxChars: maxChunkChars,
+        overlapChars: overlapChars,
+      ),
+      'bench-file',
+    );
+
+    await closeDbPool();
+    if (await benchFile.exists()) {
+      await benchFile.delete();
+    }
+    if (await benchTextFile.exists()) {
+      await benchTextFile.delete();
+    }
+    if (restoreDbPath != null) {
+      await initDbPool(dbPath: restoreDbPath, maxSize: 4);
+    }
+
+    return IngestFfiEntrypointBenchResult(
+      docBytes: docUtf8Bytes,
+      stringPath: stringStats,
+      utf8Path: utf8Stats,
+      filePath: fileStats,
+    );
+  }
+
   /// Builds a deterministic ASCII document of roughly [targetBytes] bytes by
   /// repeating a paragraph fixture. ASCII-only so `String.length` == UTF-8
   /// byte count.
@@ -590,6 +729,49 @@ class IngestFfiBenchResult {
       '    take_embedding_batch out:    ${fmt(session.sessionEmbeddingTextOutBytes.toInt())}',
       '  Reduction: ${((1 - reductionRatio) * 100).toStringAsFixed(1)}%'
           ' (session / legacy = ${reductionRatio.toStringAsFixed(2)})',
+    ].join('\n');
+  }
+}
+
+/// Result of [BenchmarkService.benchmarkIngestFfiEntrypoints].
+///
+/// Each `*Path` field is the counter snapshot taken immediately after that
+/// entrypoint variant ran. Tests compare per-variant
+/// `session_prepare_content_in_bytes` against `docBytes` to verify the
+/// pass-through claim of [ingest_session.prepareSourceIngestionFromUtf8] and
+/// [ingest_session.prepareSourceIngestionFromFile].
+class IngestFfiEntrypointBenchResult {
+  /// Document size in UTF-8 bytes.
+  final int docBytes;
+
+  /// Counter snapshot for the canonical String entrypoint.
+  final ingest_metrics.IngestTrafficStats stringPath;
+
+  /// Counter snapshot for the UTF-8 bytes entrypoint.
+  final ingest_metrics.IngestTrafficStats utf8Path;
+
+  /// Counter snapshot for the file-path entrypoint.
+  final ingest_metrics.IngestTrafficStats filePath;
+
+  const IngestFfiEntrypointBenchResult({
+    required this.docBytes,
+    required this.stringPath,
+    required this.utf8Path,
+    required this.filePath,
+  });
+
+  int get stringPrepareInBytes =>
+      stringPath.sessionPrepareContentInBytes.toInt();
+  int get utf8PrepareInBytes => utf8Path.sessionPrepareContentInBytes.toInt();
+  int get filePrepareInBytes => filePath.sessionPrepareContentInBytes.toInt();
+
+  String renderSummary() {
+    String fmt(int bytes) => '${(bytes / 1024).toStringAsFixed(1)} KB';
+    return [
+      'Ingest FFI entrypoint comparison ($docBytes B doc):',
+      '  prepareSourceIngestion(String):   prepare_in=${fmt(stringPrepareInBytes)}',
+      '  prepareSourceIngestionFromUtf8:   prepare_in=${fmt(utf8PrepareInBytes)}',
+      '  prepareSourceIngestionFromFile:   prepare_in=${fmt(filePrepareInBytes)}',
     ].join('\n');
   }
 }

--- a/lib/services/source_rag_service.dart
+++ b/lib/services/source_rag_service.dart
@@ -16,7 +16,6 @@ import '../src/rust/api/error.dart';
 import '../src/rust/api/source_rag.dart' as rust_rag;
 import '../src/rust/api/source_rag.dart'
     show SourceStats, ChunkSearchResult, SourceEntry;
-import '../src/rust/api/document_parser.dart' as rust_document_parser;
 import '../src/rust/api/ingest_session.dart' as rust_ingest;
 import '../src/rust/api/hybrid_search.dart' as hybrid;
 import 'context_builder.dart';
@@ -561,6 +560,23 @@ class SourceRagService {
       maxChars: maxChunkChars,
       overlapChars: overlapChars,
     );
+    return _runPreparedIngestion(
+      prepared,
+      chunkDelay: chunkDelay,
+      onProgress: onProgress,
+    );
+  }
+
+  /// Shared drain loop for every `prepareSourceIngestion*` entrypoint.
+  ///
+  /// Handles duplicate-skip / duplicate-in-progress states, runs the
+  /// embedding micro-batch pipeline, and finalizes / aborts / disposes the
+  /// session. Keeps the public ingest entrypoints identical in behavior.
+  Future<SourceAddResult> _runPreparedIngestion(
+    rust_ingest.PreparedIngestion prepared, {
+    Duration? chunkDelay,
+    void Function(int done, int total)? onProgress,
+  }) async {
     final sourceId = prepared.sourceId.toInt();
 
     switch (prepared.state) {
@@ -666,7 +682,12 @@ class SourceRagService {
   }
 
   /// Add a document from UTF-8 bytes while avoiding caller-side String inflation.
-  /// Add a UTF-8 payload while reducing input-side Dart String materialization.
+  ///
+  /// The bytes are handed directly to Rust, which decodes UTF-8 once and runs
+  /// the ingest pipeline without round-tripping the body through a Dart
+  /// `String`. For a 4 MB UTF-8 buffer this saves the ~8 MB Dart heap UTF-16
+  /// allocation and one Rust→Dart→Rust traffic leg compared to the legacy
+  /// `extractTextFromUtf8 → addSourceWithChunking` two-step.
   Future<SourceAddResult> addSourceUtf8WithChunking(
     List<int> bytes, {
     String? metadata,
@@ -675,20 +696,32 @@ class SourceRagService {
     Duration? chunkDelay,
     void Function(int done, int total)? onProgress,
   }) async {
-    final content = await rust_document_parser.extractTextFromUtf8(
-      fileBytes: bytes,
-    );
-    return addSourceWithChunking(
-      content,
+    final effectiveStrategy = strategy ?? ChunkingStrategy.recursive;
+    final prepared = await rust_ingest.prepareSourceIngestionFromUtf8(
+      collectionId: collectionId,
+      contentBytes: bytes,
       metadata: metadata,
       name: name,
-      strategy: strategy ?? ChunkingStrategy.recursive,
+      strategy: _toIngestStrategy(effectiveStrategy),
+      maxChars: maxChunkChars,
+      overlapChars: overlapChars,
+    );
+    return _runPreparedIngestion(
+      prepared,
       chunkDelay: chunkDelay,
       onProgress: onProgress,
     );
   }
 
   /// Add a document from a file path using a Rust-side ingest fast path.
+  ///
+  /// The file body never crosses the FFI boundary — Rust reads the file
+  /// itself and runs the rest of the staging pipeline locally. Only the path
+  /// string is sent Dart→Rust. Strategy is auto-detected from the extension
+  /// when [strategy] is `null` (`.md` / `.markdown` → Markdown, else
+  /// Recursive). Text-like extensions (`.txt`, `.md`, `.markdown`) are
+  /// decoded as UTF-8; everything else falls through to the magic-byte
+  /// document extractor (PDF / DOCX).
   Future<SourceAddResult> addSourceFromFileWithChunking(
     String filePath, {
     String? metadata,
@@ -697,15 +730,17 @@ class SourceRagService {
     Duration? chunkDelay,
     void Function(int done, int total)? onProgress,
   }) async {
-    final content = await rust_document_parser.extractTextFromFile(
+    final prepared = await rust_ingest.prepareSourceIngestionFromFile(
+      collectionId: collectionId,
       filePath: filePath,
-    );
-    return addSourceWithChunking(
-      content,
       metadata: metadata,
-      name: name,
-      filePath: filePath,
-      strategy: strategy,
+      name: name ?? filePath,
+      strategyHint: strategy == null ? null : _toIngestStrategy(strategy),
+      maxChars: maxChunkChars,
+      overlapChars: overlapChars,
+    );
+    return _runPreparedIngestion(
+      prepared,
       chunkDelay: chunkDelay,
       onProgress: onProgress,
     );

--- a/lib/src/rust/api/ingest_session.dart
+++ b/lib/src/rust/api/ingest_session.dart
@@ -7,7 +7,7 @@ import '../frb_generated.dart';
 import 'error.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `decide_duplicate_decision`, `decode_structured_chunk_type`, `encode_structured_chunk_type`, `ensure_active`, `render_context_text`
+// These functions are ignored because they are not marked as `pub`: `decide_duplicate_decision`, `decode_structured_chunk_type`, `encode_structured_chunk_type`, `ensure_active`, `prepare_source_ingestion_inner`, `render_context_text`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `DuplicateDecision`, `SessionState`, `StagedChunk`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
 
@@ -28,6 +28,53 @@ Future<PreparedIngestion> prepareSourceIngestion({
   metadata: metadata,
   name: name,
   strategy: strategy,
+  maxChars: maxChars,
+  overlapChars: overlapChars,
+);
+
+/// UTF-8 bytes variant: skips the Dart `String` materialization step. The
+/// caller hands raw bytes (typically a `Uint8List` from a file/network read);
+/// the Rust side performs UTF-8 decoding once. Identical staging behavior to
+/// `prepare_source_ingestion` once the bytes are decoded.
+Future<PreparedIngestion> prepareSourceIngestionFromUtf8({
+  required String collectionId,
+  required List<int> contentBytes,
+  String? metadata,
+  String? name,
+  required IngestStrategy strategy,
+  required int maxChars,
+  required int overlapChars,
+}) => RustLib.instance.api.crateApiIngestSessionPrepareSourceIngestionFromUtf8(
+  collectionId: collectionId,
+  contentBytes: contentBytes,
+  metadata: metadata,
+  name: name,
+  strategy: strategy,
+  maxChars: maxChars,
+  overlapChars: overlapChars,
+);
+
+/// File-path variant: Rust reads the file and never round-trips its body
+/// through Dart. Only the path string crosses FFI (Dart→Rust). When
+/// `strategy_hint` is `None`, the chunking strategy is inferred from the
+/// extension (`.md` / `.markdown` → Markdown, otherwise Recursive). Text-like
+/// extensions (`.txt`, `.md`, `.markdown`) are decoded as UTF-8; everything
+/// else falls through to `document_parser::extract_text_from_document` (PDF /
+/// DOCX magic-byte routing).
+Future<PreparedIngestion> prepareSourceIngestionFromFile({
+  required String collectionId,
+  required String filePath,
+  String? metadata,
+  String? name,
+  IngestStrategy? strategyHint,
+  required int maxChars,
+  required int overlapChars,
+}) => RustLib.instance.api.crateApiIngestSessionPrepareSourceIngestionFromFile(
+  collectionId: collectionId,
+  filePath: filePath,
+  metadata: metadata,
+  name: name,
+  strategyHint: strategyHint,
   maxChars: maxChars,
   overlapChars: overlapChars,
 );

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -82,7 +82,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1393277997;
+  int get rustContentHash => 1317836089;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -451,6 +451,28 @@ abstract class RustLibApi extends BaseApi {
   Future<PreparedIngestion> crateApiIngestSessionPrepareSourceIngestion({
     required String collectionId,
     required String content,
+    String? metadata,
+    String? name,
+    required IngestStrategy strategy,
+    required int maxChars,
+    required int overlapChars,
+  });
+
+  Future<PreparedIngestion>
+  crateApiIngestSessionPrepareSourceIngestionFromFile({
+    required String collectionId,
+    required String filePath,
+    String? metadata,
+    String? name,
+    IngestStrategy? strategyHint,
+    required int maxChars,
+    required int overlapChars,
+  });
+
+  Future<PreparedIngestion>
+  crateApiIngestSessionPrepareSourceIngestionFromUtf8({
+    required String collectionId,
+    required List<int> contentBytes,
     String? metadata,
     String? name,
     required IngestStrategy strategy,
@@ -3724,6 +3746,134 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<PreparedIngestion>
+  crateApiIngestSessionPrepareSourceIngestionFromFile({
+    required String collectionId,
+    required String filePath,
+    String? metadata,
+    String? name,
+    IngestStrategy? strategyHint,
+    required int maxChars,
+    required int overlapChars,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(collectionId, serializer);
+          sse_encode_String(filePath, serializer);
+          sse_encode_opt_String(metadata, serializer);
+          sse_encode_opt_String(name, serializer);
+          sse_encode_opt_box_autoadd_ingest_strategy(strategyHint, serializer);
+          sse_encode_i_32(maxChars, serializer);
+          sse_encode_i_32(overlapChars, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 98,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_prepared_ingestion,
+          decodeErrorData: sse_decode_rag_error,
+        ),
+        constMeta:
+            kCrateApiIngestSessionPrepareSourceIngestionFromFileConstMeta,
+        argValues: [
+          collectionId,
+          filePath,
+          metadata,
+          name,
+          strategyHint,
+          maxChars,
+          overlapChars,
+        ],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiIngestSessionPrepareSourceIngestionFromFileConstMeta =>
+      const TaskConstMeta(
+        debugName: "prepare_source_ingestion_from_file",
+        argNames: [
+          "collectionId",
+          "filePath",
+          "metadata",
+          "name",
+          "strategyHint",
+          "maxChars",
+          "overlapChars",
+        ],
+      );
+
+  @override
+  Future<PreparedIngestion>
+  crateApiIngestSessionPrepareSourceIngestionFromUtf8({
+    required String collectionId,
+    required List<int> contentBytes,
+    String? metadata,
+    String? name,
+    required IngestStrategy strategy,
+    required int maxChars,
+    required int overlapChars,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(collectionId, serializer);
+          sse_encode_list_prim_u_8_loose(contentBytes, serializer);
+          sse_encode_opt_String(metadata, serializer);
+          sse_encode_opt_String(name, serializer);
+          sse_encode_ingest_strategy(strategy, serializer);
+          sse_encode_i_32(maxChars, serializer);
+          sse_encode_i_32(overlapChars, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 99,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_prepared_ingestion,
+          decodeErrorData: sse_decode_rag_error,
+        ),
+        constMeta:
+            kCrateApiIngestSessionPrepareSourceIngestionFromUtf8ConstMeta,
+        argValues: [
+          collectionId,
+          contentBytes,
+          metadata,
+          name,
+          strategy,
+          maxChars,
+          overlapChars,
+        ],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiIngestSessionPrepareSourceIngestionFromUtf8ConstMeta =>
+      const TaskConstMeta(
+        debugName: "prepare_source_ingestion_from_utf8",
+        argNames: [
+          "collectionId",
+          "contentBytes",
+          "metadata",
+          "name",
+          "strategy",
+          "maxChars",
+          "overlapChars",
+        ],
+      );
+
+  @override
   Future<void> crateApiSimpleRagRebuildBm25Index() {
     return handler.executeNormal(
       NormalTask(
@@ -3732,7 +3882,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 100,
             port: port_,
           );
         },
@@ -3759,7 +3909,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 101,
             port: port_,
           );
         },
@@ -3789,7 +3939,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 102,
             port: port_,
           );
         },
@@ -3821,7 +3971,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 103,
             port: port_,
           );
         },
@@ -3851,7 +4001,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 104,
             port: port_,
           );
         },
@@ -3883,7 +4033,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 105,
             port: port_,
           );
         },
@@ -3910,7 +4060,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 106,
           )!;
         },
         codec: SseCodec(
@@ -3939,7 +4089,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 107,
             port: port_,
           );
         },
@@ -3971,7 +4121,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 108,
             port: port_,
           );
         },
@@ -4002,7 +4152,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 109,
             port: port_,
           );
         },
@@ -4034,7 +4184,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 110,
             port: port_,
           );
         },
@@ -4071,7 +4221,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 111,
             port: port_,
           );
         },
@@ -4106,7 +4256,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 112,
             port: port_,
           );
         },
@@ -4141,7 +4291,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 113,
             port: port_,
           );
         },
@@ -4182,7 +4332,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 114,
             port: port_,
           );
         },
@@ -4219,7 +4369,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 115,
             port: port_,
           );
         },
@@ -4260,7 +4410,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 116,
             port: port_,
           );
         },
@@ -4308,7 +4458,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 117,
             port: port_,
           );
         },
@@ -4344,7 +4494,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 118,
             port: port_,
           );
         },
@@ -4379,7 +4529,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 119,
           )!;
         },
         codec: SseCodec(
@@ -4415,7 +4565,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 120,
           )!;
         },
         codec: SseCodec(
@@ -4447,7 +4597,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 121,
             port: port_,
           );
         },
@@ -4479,7 +4629,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 122,
             port: port_,
           );
         },
@@ -4512,7 +4662,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 123,
             port: port_,
           );
         },
@@ -4540,7 +4690,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 124,
           )!;
         },
         codec: SseCodec(
@@ -4571,7 +4721,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 125,
             port: port_,
           );
         },
@@ -4606,7 +4756,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 126,
             port: port_,
           );
         },
@@ -4639,7 +4789,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 127,
             port: port_,
           );
         },
@@ -4672,7 +4822,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 128,
             port: port_,
           );
         },
@@ -4910,6 +5060,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PlatformInt64 dco_decode_box_autoadd_i_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_i_64(raw);
+  }
+
+  @protected
+  IngestStrategy dco_decode_box_autoadd_ingest_strategy(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_ingest_strategy(raw);
   }
 
   @protected
@@ -5391,6 +5547,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PlatformInt64? dco_decode_opt_box_autoadd_i_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_i_64(raw);
+  }
+
+  @protected
+  IngestStrategy? dco_decode_opt_box_autoadd_ingest_strategy(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_ingest_strategy(raw);
   }
 
   @protected
@@ -5937,6 +6099,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PlatformInt64 sse_decode_box_autoadd_i_64(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_i_64(deserializer));
+  }
+
+  @protected
+  IngestStrategy sse_decode_box_autoadd_ingest_strategy(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_ingest_strategy(deserializer));
   }
 
   @protected
@@ -6605,6 +6775,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  IngestStrategy? sse_decode_opt_box_autoadd_ingest_strategy(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_ingest_strategy(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   (int, int, int)? sse_decode_opt_box_autoadd_record_u_32_u_32_u_32(
     SseDeserializer deserializer,
   ) {
@@ -7221,6 +7404,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_ingest_strategy(
+    IngestStrategy self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_ingest_strategy(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_ingest_traffic_stats(
     IngestTrafficStats self,
     SseSerializer serializer,
@@ -7827,6 +8019,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self != null, serializer);
     if (self != null) {
       sse_encode_box_autoadd_i_64(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_ingest_strategy(
+    IngestStrategy? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_ingest_strategy(self, serializer);
     }
   }
 

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -138,6 +138,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PlatformInt64 dco_decode_box_autoadd_i_64(dynamic raw);
 
   @protected
+  IngestStrategy dco_decode_box_autoadd_ingest_strategy(dynamic raw);
+
+  @protected
   IngestTrafficStats dco_decode_box_autoadd_ingest_traffic_stats(dynamic raw);
 
   @protected
@@ -312,6 +315,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64? dco_decode_opt_box_autoadd_i_64(dynamic raw);
+
+  @protected
+  IngestStrategy? dco_decode_opt_box_autoadd_ingest_strategy(dynamic raw);
 
   @protected
   (int, int, int)? dco_decode_opt_box_autoadd_record_u_32_u_32_u_32(
@@ -499,6 +505,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64 sse_decode_box_autoadd_i_64(SseDeserializer deserializer);
+
+  @protected
+  IngestStrategy sse_decode_box_autoadd_ingest_strategy(
+    SseDeserializer deserializer,
+  );
 
   @protected
   IngestTrafficStats sse_decode_box_autoadd_ingest_traffic_stats(
@@ -725,6 +736,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PlatformInt64? sse_decode_opt_box_autoadd_i_64(SseDeserializer deserializer);
 
   @protected
+  IngestStrategy? sse_decode_opt_box_autoadd_ingest_strategy(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   (int, int, int)? sse_decode_opt_box_autoadd_record_u_32_u_32_u_32(
     SseDeserializer deserializer,
   );
@@ -947,6 +963,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_i_64(
     PlatformInt64 self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_ingest_strategy(
+    IngestStrategy self,
     SseSerializer serializer,
   );
 
@@ -1248,6 +1270,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_opt_box_autoadd_i_64(
     PlatformInt64? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_box_autoadd_ingest_strategy(
+    IngestStrategy? self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -140,6 +140,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PlatformInt64 dco_decode_box_autoadd_i_64(dynamic raw);
 
   @protected
+  IngestStrategy dco_decode_box_autoadd_ingest_strategy(dynamic raw);
+
+  @protected
   IngestTrafficStats dco_decode_box_autoadd_ingest_traffic_stats(dynamic raw);
 
   @protected
@@ -314,6 +317,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64? dco_decode_opt_box_autoadd_i_64(dynamic raw);
+
+  @protected
+  IngestStrategy? dco_decode_opt_box_autoadd_ingest_strategy(dynamic raw);
 
   @protected
   (int, int, int)? dco_decode_opt_box_autoadd_record_u_32_u_32_u_32(
@@ -501,6 +507,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64 sse_decode_box_autoadd_i_64(SseDeserializer deserializer);
+
+  @protected
+  IngestStrategy sse_decode_box_autoadd_ingest_strategy(
+    SseDeserializer deserializer,
+  );
 
   @protected
   IngestTrafficStats sse_decode_box_autoadd_ingest_traffic_stats(
@@ -727,6 +738,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   PlatformInt64? sse_decode_opt_box_autoadd_i_64(SseDeserializer deserializer);
 
   @protected
+  IngestStrategy? sse_decode_opt_box_autoadd_ingest_strategy(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   (int, int, int)? sse_decode_opt_box_autoadd_record_u_32_u_32_u_32(
     SseDeserializer deserializer,
   );
@@ -949,6 +965,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_box_autoadd_i_64(
     PlatformInt64 self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_box_autoadd_ingest_strategy(
+    IngestStrategy self,
     SseSerializer serializer,
   );
 
@@ -1250,6 +1272,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_opt_box_autoadd_i_64(
     PlatformInt64? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_box_autoadd_ingest_strategy(
+    IngestStrategy? self,
     SseSerializer serializer,
   );
 

--- a/rust_builder/rust/src/api/ingest_session.rs
+++ b/rust_builder/rust/src/api/ingest_session.rs
@@ -331,12 +331,127 @@ pub fn prepare_source_ingestion(
     max_chars: i32,
     overlap_chars: i32,
 ) -> Result<PreparedIngestion, RagError> {
-    // Record the FFI byte traffic from Dart→Rust before delegating to internal
-    // helpers. The guard suppresses legacy counter increments for the nested
-    // calls (add_source_in_collection, semantic_chunk_with_overlap,
-    // markdown_chunk) so a session-path run does not double-charge legacy
-    // counters.
+    // Record the FFI byte traffic from Dart→Rust before delegating to the inner
+    // helper. `content.len()` matches the encoded UTF-8 byte length for ASCII
+    // and ≤ the actual Dart String memory cost for any input.
     SESSION_PREPARE_CONTENT_IN.record(content.len() as u64);
+    prepare_source_ingestion_inner(
+        collection_id,
+        content,
+        metadata,
+        name,
+        strategy,
+        max_chars,
+        overlap_chars,
+    )
+}
+
+/// UTF-8 bytes variant: skips the Dart `String` materialization step. The
+/// caller hands raw bytes (typically a `Uint8List` from a file/network read);
+/// the Rust side performs UTF-8 decoding once. Identical staging behavior to
+/// `prepare_source_ingestion` once the bytes are decoded.
+pub fn prepare_source_ingestion_from_utf8(
+    collection_id: String,
+    content_bytes: Vec<u8>,
+    metadata: Option<String>,
+    name: Option<String>,
+    strategy: IngestStrategy,
+    max_chars: i32,
+    overlap_chars: i32,
+) -> Result<PreparedIngestion, RagError> {
+    // `content_bytes.len()` equals the actual Dart→Rust FFI byte traffic on
+    // this entrypoint — bytes flow straight into Rust without intermediate
+    // String creation in Dart.
+    SESSION_PREPARE_CONTENT_IN.record(content_bytes.len() as u64);
+    let content = String::from_utf8(content_bytes)
+        .map_err(|e| RagError::InvalidInput(format!("UTF-8 decode failed: {}", e)))?;
+    prepare_source_ingestion_inner(
+        collection_id,
+        content,
+        metadata,
+        name,
+        strategy,
+        max_chars,
+        overlap_chars,
+    )
+}
+
+/// File-path variant: Rust reads the file and never round-trips its body
+/// through Dart. Only the path string crosses FFI (Dart→Rust). When
+/// `strategy_hint` is `None`, the chunking strategy is inferred from the
+/// extension (`.md` / `.markdown` → Markdown, otherwise Recursive). Text-like
+/// extensions (`.txt`, `.md`, `.markdown`) are decoded as UTF-8; everything
+/// else falls through to `document_parser::extract_text_from_document` (PDF /
+/// DOCX magic-byte routing).
+pub fn prepare_source_ingestion_from_file(
+    collection_id: String,
+    file_path: String,
+    metadata: Option<String>,
+    name: Option<String>,
+    strategy_hint: Option<IngestStrategy>,
+    max_chars: i32,
+    overlap_chars: i32,
+) -> Result<PreparedIngestion, RagError> {
+    let bytes = std::fs::read(&file_path)
+        .map_err(|e| RagError::IoError(format!("Failed to read file '{}': {}", file_path, e)))?;
+
+    let extension = std::path::Path::new(&file_path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase());
+    let is_text_like = matches!(extension.as_deref(), Some("txt" | "md" | "markdown"));
+
+    let content = if is_text_like {
+        String::from_utf8(bytes).map_err(|e| {
+            RagError::InvalidInput(format!("UTF-8 decode failed for '{}': {}", file_path, e))
+        })?
+    } else {
+        crate::api::document_parser::extract_text_from_document(bytes).map_err(|e| {
+            RagError::InvalidInput(format!(
+                "Document extraction failed for '{}': {}",
+                file_path, e
+            ))
+        })?
+    };
+
+    let strategy = strategy_hint.unwrap_or_else(|| {
+        if matches!(extension.as_deref(), Some("md" | "markdown")) {
+            IngestStrategy::Markdown
+        } else {
+            IngestStrategy::Recursive
+        }
+    });
+
+    // Body bytes did NOT cross FFI on this path — only the path string did.
+    // Honest counter reflects "Dart→Rust body bytes" rather than internal
+    // Rust I/O, so SESSION_PREPARE_CONTENT_IN stays unrecorded here.
+    prepare_source_ingestion_inner(
+        collection_id,
+        content,
+        metadata,
+        name,
+        strategy,
+        max_chars,
+        overlap_chars,
+    )
+}
+
+/// Shared body for all three `prepare_source_ingestion*` entrypoints.
+/// Wrappers above are responsible for counter recording and decoding inputs
+/// down to a `String` body; this function owns the source-row + claim +
+/// chunker + staging pipeline.
+fn prepare_source_ingestion_inner(
+    collection_id: String,
+    content: String,
+    metadata: Option<String>,
+    name: Option<String>,
+    strategy: IngestStrategy,
+    max_chars: i32,
+    overlap_chars: i32,
+) -> Result<PreparedIngestion, RagError> {
+    // The guard suppresses legacy counter increments for the nested calls
+    // (add_source_in_collection, semantic_chunk_with_overlap, markdown_chunk)
+    // so a session-path run does not double-charge legacy counters.
     let _legacy_guard = LegacyCountingGuard::enter();
 
     let add_result =
@@ -986,6 +1101,276 @@ mod tests {
         session.finalize().unwrap();
 
         drop(session);
+        teardown_test_db(db_path);
+    }
+
+    #[test]
+    fn test_prepare_from_utf8_matches_string_path() {
+        // Validates that `prepare_source_ingestion_from_utf8` produces an
+        // equivalent CreatedReady session for valid UTF-8 input.
+        let _guard = test_guard();
+        let db_path = setup_test_db("test_ingest_prepare_from_utf8_ok.db");
+
+        let content = "Bytes path body. 한글 포함.".to_string();
+        let prepared = prepare_source_ingestion_from_utf8(
+            "__default__".to_string(),
+            content.into_bytes(),
+            None,
+            Some("utf8.txt".to_string()),
+            IngestStrategy::Recursive,
+            120,
+            0,
+        )
+        .unwrap();
+
+        assert_eq!(prepared.state, PreparedSourceState::CreatedReady);
+        assert!(prepared.total_chunks >= 1);
+        let session_opaque = prepared.session.unwrap();
+        let mut session = session_opaque.blocking_write();
+        let saved = drain_session_with_fake_embeddings(&mut session);
+        assert_eq!(saved, prepared.total_chunks);
+        session.finalize().unwrap();
+
+        drop(session);
+        teardown_test_db(db_path);
+    }
+
+    #[test]
+    fn test_prepare_from_utf8_rejects_invalid_bytes() {
+        let _guard = test_guard();
+        let db_path = setup_test_db("test_ingest_prepare_from_utf8_invalid.db");
+
+        // 0xFF is not valid UTF-8 in any position.
+        let invalid = vec![0x48, 0x65, 0x6C, 0xFF, 0x6F];
+        let result = prepare_source_ingestion_from_utf8(
+            "__default__".to_string(),
+            invalid,
+            None,
+            Some("bad.txt".to_string()),
+            IngestStrategy::Recursive,
+            120,
+            0,
+        );
+        match result {
+            Err(RagError::InvalidInput(msg)) => {
+                assert!(msg.contains("UTF-8 decode failed"), "msg={}", msg)
+            }
+            Err(other) => panic!("expected InvalidInput, got {:?}", other),
+            Ok(_) => panic!("expected error for invalid UTF-8 bytes"),
+        }
+
+        teardown_test_db(db_path);
+    }
+
+    #[test]
+    fn test_prepare_from_utf8_empty_input_creates_zero_chunks() {
+        let _guard = test_guard();
+        let db_path = setup_test_db("test_ingest_prepare_from_utf8_empty.db");
+
+        let prepared = prepare_source_ingestion_from_utf8(
+            "__default__".to_string(),
+            Vec::new(),
+            None,
+            Some("empty.txt".to_string()),
+            IngestStrategy::Recursive,
+            120,
+            0,
+        )
+        .unwrap();
+        // Empty body: chunker yields nothing, finalize on a zero-chunk session
+        // is allowed (matches semantic_chunk_with_overlap on empty input).
+        assert!(matches!(
+            prepared.state,
+            PreparedSourceState::CreatedReady | PreparedSourceState::ResumeReady,
+        ));
+        assert_eq!(prepared.total_chunks, 0);
+        let session_opaque = prepared.session.unwrap();
+        let mut session = session_opaque.blocking_write();
+        session.finalize().unwrap();
+        drop(session);
+
+        teardown_test_db(db_path);
+    }
+
+    #[test]
+    fn test_prepare_from_file_reads_txt_and_md_with_auto_strategy() {
+        let _guard = test_guard();
+        let db_path = setup_test_db("test_ingest_prepare_from_file_textlike.db");
+
+        let tmp = std::env::temp_dir();
+        let txt_path = tmp.join("ingest_session_from_file_plain.txt");
+        let md_path = tmp.join("ingest_session_from_file_doc.md");
+        std::fs::write(&txt_path, "Plain text body for ingest from file test.").unwrap();
+        std::fs::write(
+            &md_path,
+            "# Header One\n\nMarkdown intro paragraph.\n\n## Sub\n\nDetail body.\n",
+        )
+        .unwrap();
+
+        // .txt → Recursive (no header_path encoding expected).
+        let txt_prepared = prepare_source_ingestion_from_file(
+            "__default__".to_string(),
+            txt_path.to_string_lossy().into_owned(),
+            None,
+            Some("plain.txt".to_string()),
+            None, // auto-detect
+            200,
+            0,
+        )
+        .unwrap();
+        assert_eq!(txt_prepared.state, PreparedSourceState::CreatedReady);
+        assert!(txt_prepared.total_chunks >= 1);
+        let txt_session_opaque = txt_prepared.session.unwrap();
+        {
+            let mut session = txt_session_opaque.blocking_write();
+            drain_session_with_fake_embeddings(&mut session);
+            session.finalize().unwrap();
+        }
+
+        // .md → Markdown (at least one chunk should carry "Header Path: ").
+        let md_prepared = prepare_source_ingestion_from_file(
+            "__default__".to_string(),
+            md_path.to_string_lossy().into_owned(),
+            None,
+            Some("doc.md".to_string()),
+            None, // auto-detect → Markdown
+            200,
+            0,
+        )
+        .unwrap();
+        assert_eq!(md_prepared.state, PreparedSourceState::CreatedReady);
+        let md_session_opaque = md_prepared.session.unwrap();
+        {
+            let mut session = md_session_opaque.blocking_write();
+            let batch = session.take_embedding_batch(md_prepared.total_chunks).unwrap();
+            let has_header_path = batch
+                .iter()
+                .any(|req| req.embedding_text.starts_with("Header Path: "));
+            assert!(
+                has_header_path,
+                "markdown auto-strategy must propagate header path through embedding_text",
+            );
+            let embeddings: Vec<ChunkEmbedding> = batch
+                .into_iter()
+                .map(|req| ChunkEmbedding {
+                    chunk_index: req.chunk_index,
+                    embedding: fake_embedding(4, req.chunk_index as f32),
+                })
+                .collect();
+            session.commit_embeddings(embeddings).unwrap();
+            session.finalize().unwrap();
+        }
+
+        let _ = std::fs::remove_file(txt_path);
+        let _ = std::fs::remove_file(md_path);
+        teardown_test_db(db_path);
+    }
+
+    #[test]
+    fn test_prepare_from_file_missing_path_returns_io_error() {
+        let _guard = test_guard();
+        let db_path = setup_test_db("test_ingest_prepare_from_file_missing.db");
+
+        let missing = std::env::temp_dir()
+            .join("definitely_does_not_exist_ingest_session.txt")
+            .to_string_lossy()
+            .into_owned();
+        let result = prepare_source_ingestion_from_file(
+            "__default__".to_string(),
+            missing,
+            None,
+            None,
+            None,
+            120,
+            0,
+        );
+        match result {
+            Err(RagError::IoError(msg)) => {
+                assert!(msg.contains("Failed to read file"), "msg={}", msg)
+            }
+            Err(other) => panic!("expected IoError, got {:?}", other),
+            Ok(_) => panic!("expected error for missing file"),
+        }
+
+        teardown_test_db(db_path);
+    }
+
+    #[test]
+    fn test_prepare_from_file_does_not_record_session_prepare_content() {
+        // Regression guard: from_file must not record the body bytes into
+        // SESSION_PREPARE_CONTENT_IN, because the body never crossed FFI.
+        use crate::api::ingest_metrics::{reset_ingest_traffic_stats, ingest_traffic_stats};
+
+        let _guard = test_guard();
+        let db_path = setup_test_db("test_ingest_prepare_from_file_counter.db");
+
+        let tmp = std::env::temp_dir();
+        let txt_path = tmp.join("ingest_session_from_file_counter.txt");
+        let body = "This is a sufficiently long body of text to cross a kilobyte ".repeat(64);
+        std::fs::write(&txt_path, &body).unwrap();
+
+        reset_ingest_traffic_stats();
+        let prepared = prepare_source_ingestion_from_file(
+            "__default__".to_string(),
+            txt_path.to_string_lossy().into_owned(),
+            None,
+            Some("counter.txt".to_string()),
+            None,
+            500,
+            0,
+        )
+        .unwrap();
+        let stats = ingest_traffic_stats();
+        assert_eq!(
+            stats.session_prepare_content_in_bytes, 0,
+            "from_file must not credit body bytes to SESSION_PREPARE_CONTENT_IN",
+        );
+        assert_eq!(stats.session_prepare_content_in_calls, 0);
+
+        // Clean up the session so teardown is deterministic.
+        if let Some(session_opaque) = prepared.session {
+            let mut session = session_opaque.blocking_write();
+            drain_session_with_fake_embeddings(&mut session);
+            session.finalize().unwrap();
+        }
+
+        let _ = std::fs::remove_file(txt_path);
+        teardown_test_db(db_path);
+    }
+
+    #[test]
+    fn test_prepare_from_utf8_records_bytes_len_into_counter() {
+        // Regression guard: from_utf8 must credit its byte payload to
+        // SESSION_PREPARE_CONTENT_IN (and exactly once).
+        use crate::api::ingest_metrics::{reset_ingest_traffic_stats, ingest_traffic_stats};
+
+        let _guard = test_guard();
+        let db_path = setup_test_db("test_ingest_prepare_from_utf8_counter.db");
+
+        let body = "Counter check body.".to_string();
+        let expected = body.len() as u64;
+
+        reset_ingest_traffic_stats();
+        let prepared = prepare_source_ingestion_from_utf8(
+            "__default__".to_string(),
+            body.into_bytes(),
+            None,
+            Some("counter-utf8.txt".to_string()),
+            IngestStrategy::Recursive,
+            120,
+            0,
+        )
+        .unwrap();
+        let stats = ingest_traffic_stats();
+        assert_eq!(stats.session_prepare_content_in_bytes, expected);
+        assert_eq!(stats.session_prepare_content_in_calls, 1);
+
+        if let Some(session_opaque) = prepared.session {
+            let mut session = session_opaque.blocking_write();
+            drain_session_with_fake_embeddings(&mut session);
+            session.finalize().unwrap();
+        }
+
         teardown_test_db(db_path);
     }
 }

--- a/rust_builder/rust/src/frb_generated.rs
+++ b/rust_builder/rust/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1393277997;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1317836089;
 
 // Section: executor
 
@@ -3658,6 +3658,102 @@ fn wire__crate__api__ingest_session__prepare_source_ingestion_impl(
         },
     )
 }
+fn wire__crate__api__ingest_session__prepare_source_ingestion_from_file_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "prepare_source_ingestion_from_file",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_collection_id = <String>::sse_decode(&mut deserializer);
+            let api_file_path = <String>::sse_decode(&mut deserializer);
+            let api_metadata = <Option<String>>::sse_decode(&mut deserializer);
+            let api_name = <Option<String>>::sse_decode(&mut deserializer);
+            let api_strategy_hint =
+                <Option<crate::api::ingest_session::IngestStrategy>>::sse_decode(&mut deserializer);
+            let api_max_chars = <i32>::sse_decode(&mut deserializer);
+            let api_overlap_chars = <i32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::error::RagError>((move || {
+                    let output_ok = crate::api::ingest_session::prepare_source_ingestion_from_file(
+                        api_collection_id,
+                        api_file_path,
+                        api_metadata,
+                        api_name,
+                        api_strategy_hint,
+                        api_max_chars,
+                        api_overlap_chars,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__ingest_session__prepare_source_ingestion_from_utf8_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "prepare_source_ingestion_from_utf8",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_collection_id = <String>::sse_decode(&mut deserializer);
+            let api_content_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_metadata = <Option<String>>::sse_decode(&mut deserializer);
+            let api_name = <Option<String>>::sse_decode(&mut deserializer);
+            let api_strategy =
+                <crate::api::ingest_session::IngestStrategy>::sse_decode(&mut deserializer);
+            let api_max_chars = <i32>::sse_decode(&mut deserializer);
+            let api_overlap_chars = <i32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::error::RagError>((move || {
+                    let output_ok = crate::api::ingest_session::prepare_source_ingestion_from_utf8(
+                        api_collection_id,
+                        api_content_bytes,
+                        api_metadata,
+                        api_name,
+                        api_strategy,
+                        api_max_chars,
+                        api_overlap_chars,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__simple_rag__rebuild_bm25_index_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -5531,6 +5627,19 @@ impl SseDecode for Option<i64> {
     }
 }
 
+impl SseDecode for Option<crate::api::ingest_session::IngestStrategy> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<crate::api::ingest_session::IngestStrategy>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for Option<(u32, u32, u32)> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -6335,118 +6444,130 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        98 => {
+        98 => wire__crate__api__ingest_session__prepare_source_ingestion_from_file_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        99 => wire__crate__api__ingest_session__prepare_source_ingestion_from_utf8_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        100 => {
             wire__crate__api__simple_rag__rebuild_bm25_index_impl(port, ptr, rust_vec_len, data_len)
         }
-        99 => wire__crate__api__source_rag__rebuild_chunk_bm25_index_impl(
+        101 => wire__crate__api__source_rag__rebuild_chunk_bm25_index_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        100 => wire__crate__api__source_rag__rebuild_chunk_bm25_index_for_collection_impl(
+        102 => wire__crate__api__source_rag__rebuild_chunk_bm25_index_for_collection_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        101 => wire__crate__api__source_rag__rebuild_chunk_hnsw_index_impl(
+        103 => wire__crate__api__source_rag__rebuild_chunk_hnsw_index_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        102 => wire__crate__api__source_rag__rebuild_chunk_hnsw_index_for_collection_impl(
+        104 => wire__crate__api__source_rag__rebuild_chunk_hnsw_index_for_collection_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        103 => {
+        105 => {
             wire__crate__api__simple_rag__rebuild_hnsw_index_impl(port, ptr, rust_vec_len, data_len)
         }
-        105 => wire__crate__api__hybrid_search__rrf_config_default_impl(
+        107 => wire__crate__api__hybrid_search__rrf_config_default_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        106 => wire__crate__api__source_rag__save_collection_hnsw_index_impl(
+        108 => wire__crate__api__source_rag__save_collection_hnsw_index_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        107 => {
+        109 => {
             wire__crate__api__hnsw_index__save_hnsw_index_impl(port, ptr, rust_vec_len, data_len)
         }
-        108 => wire__crate__api__source_rag__search_chunks_impl(port, ptr, rust_vec_len, data_len),
-        109 => wire__crate__api__source_rag__search_chunks_in_collection_impl(
+        110 => wire__crate__api__source_rag__search_chunks_impl(port, ptr, rust_vec_len, data_len),
+        111 => wire__crate__api__source_rag__search_chunks_in_collection_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        110 => wire__crate__api__hnsw_index__search_hnsw_impl(port, ptr, rust_vec_len, data_len),
-        111 => {
+        112 => wire__crate__api__hnsw_index__search_hnsw_impl(port, ptr, rust_vec_len, data_len),
+        113 => {
             wire__crate__api__hnsw_index__search_hnsw_slice_impl(port, ptr, rust_vec_len, data_len)
         }
-        112 => {
+        114 => {
             wire__crate__api__hybrid_search__search_hybrid_impl(port, ptr, rust_vec_len, data_len)
         }
-        113 => wire__crate__api__hybrid_search__search_hybrid_simple_impl(
+        115 => wire__crate__api__hybrid_search__search_hybrid_simple_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        114 => wire__crate__api__hybrid_search__search_hybrid_weighted_impl(
+        116 => wire__crate__api__hybrid_search__search_hybrid_weighted_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        115 => {
+        117 => {
             wire__crate__api__source_rag__search_meta_hybrid_impl(port, ptr, rust_vec_len, data_len)
         }
-        116 => wire__crate__api__simple_rag__search_similar_impl(port, ptr, rust_vec_len, data_len),
-        119 => wire__crate__api__compression_utils__sentence_hash_impl(
+        118 => wire__crate__api__simple_rag__search_similar_impl(port, ptr, rust_vec_len, data_len),
+        121 => wire__crate__api__compression_utils__sentence_hash_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        120 => wire__crate__api__compression_utils__should_compress_impl(
+        122 => wire__crate__api__compression_utils__should_compress_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        121 => wire__crate__api__compression_utils__split_sentences_impl(
+        123 => wire__crate__api__compression_utils__split_sentences_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        123 => wire__crate__api__source_rag__update_chunk_embedding_impl(
+        125 => wire__crate__api__source_rag__update_chunk_embedding_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        124 => wire__crate__api__source_rag__update_source_status_impl(
+        126 => wire__crate__api__source_rag__update_source_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        125 => wire__crate__api__user_intent__user_intent_get_query_impl(
+        127 => wire__crate__api__user_intent__user_intent_get_query_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        126 => wire__crate__api__user_intent__user_intent_intent_type_impl(
+        128 => wire__crate__api__user_intent__user_intent_intent_type_impl(
             port,
             ptr,
             rust_vec_len,
@@ -6482,18 +6603,18 @@ fn pde_ffi_dispatcher_sync_impl(
         93 => wire__crate__api__semantic_chunker__markdown_chunk_impl(ptr, rust_vec_len, data_len),
         95 => wire__crate__api__user_intent__parse_intent_impl(ptr, rust_vec_len, data_len),
         96 => wire__crate__api__user_intent__parse_user_intent_impl(ptr, rust_vec_len, data_len),
-        104 => wire__crate__api__ingest_metrics__reset_ingest_traffic_stats_impl(
+        106 => wire__crate__api__ingest_metrics__reset_ingest_traffic_stats_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        117 => wire__crate__api__semantic_chunker__semantic_chunk_impl(ptr, rust_vec_len, data_len),
-        118 => wire__crate__api__semantic_chunker__semantic_chunk_with_overlap_impl(
+        119 => wire__crate__api__semantic_chunker__semantic_chunk_impl(ptr, rust_vec_len, data_len),
+        120 => wire__crate__api__semantic_chunker__semantic_chunk_with_overlap_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        122 => wire__crate__api__tokenizer__tokenize_impl(ptr, rust_vec_len, data_len),
+        124 => wire__crate__api__tokenizer__tokenize_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -8015,6 +8136,16 @@ impl SseEncode for Option<i64> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <i64>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<crate::api::ingest_session::IngestStrategy> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <crate::api::ingest_session::IngestStrategy>::sse_encode(value, serializer);
         }
     }
 }

--- a/test/native/ingest_ffi_traffic_test.dart
+++ b/test/native/ingest_ffi_traffic_test.dart
@@ -97,4 +97,62 @@ void main() {
       await dir.delete(recursive: true);
     }
   });
+
+  test(
+    'FFI text traffic: from_utf8 / from_file deliver promised pass-through',
+    () async {
+      // Locks in the claim that:
+      //   - prepareSourceIngestion(String):   prepare_in == doc body bytes
+      //   - prepareSourceIngestionFromUtf8:   prepare_in == doc body bytes
+      //     (same FFI traffic, but Dart heap allocation is avoided —
+      //     measurable only at runtime, not in counters)
+      //   - prepareSourceIngestionFromFile:   prepare_in == 0
+      //     (body never crosses FFI; only the path string does)
+      final dir = await Directory.systemTemp.createTemp(
+        'mobile_rag_ffi_entrypoints_',
+      );
+      try {
+        final result = await BenchmarkService.benchmarkIngestFfiEntrypoints(
+          targetBytes: 256 * 1024,
+          maxChunkChars: 1500,
+          overlapChars: 0,
+          batchSize: 16,
+          dbPathOverride: '${dir.path}/ffi_entrypoints_bench.sqlite',
+        );
+
+        // String entrypoint records full body once.
+        expect(
+          result.stringPrepareInBytes,
+          result.docBytes,
+          reason: 'String path should record exactly docBytes into '
+              'session_prepare_content_in_bytes; got '
+              '${result.stringPrepareInBytes} vs docBytes=${result.docBytes}',
+        );
+
+        // UTF-8 entrypoint records the same byte count: bytes flow straight
+        // into Rust without a Dart String round-trip.
+        expect(
+          result.utf8PrepareInBytes,
+          result.docBytes,
+          reason: 'UTF-8 path should record exactly docBytes into '
+              'session_prepare_content_in_bytes; got '
+              '${result.utf8PrepareInBytes} vs docBytes=${result.docBytes}',
+        );
+
+        // File entrypoint records ZERO: the body never crosses FFI.
+        expect(
+          result.filePrepareInBytes,
+          0,
+          reason: 'File path must not credit body bytes to '
+              'session_prepare_content_in_bytes; the body never crosses FFI. '
+              'Got ${result.filePrepareInBytes}',
+        );
+
+        // ignore: avoid_print
+        print(result.renderSummary());
+      } finally {
+        await dir.delete(recursive: true);
+      }
+    },
+  );
 }


### PR DESCRIPTION
## Summary

- New Rust entrypoints `prepare_source_ingestion_from_utf8(bytes)` and `prepare_source_ingestion_from_file(path)` next to the existing `prepare_source_ingestion(String)`. Shared post-decode pipeline extracted into a private `prepare_source_ingestion_inner` (no behavior change on the canonical String path).
- `SourceRagService.addSourceUtf8WithChunking` and `addSourceFromFileWithChunking` now route through these new entrypoints, so:
  - UTF-8 bytes go straight into Rust (no intermediate Dart `String` — saves the Dart-heap UTF-16 inflation, ~8 MB for a 4 MB file).
  - File path mode reads the body inside Rust; only the path string crosses FFI. Strategy auto-detection (`.md` / `.markdown` → Markdown, else Recursive) and PDF/DOCX magic-byte routing happen Rust-side.
- Public Dart API signatures (`addDocument`, `addDocumentUtf8`, `addDocumentFromFile`) are unchanged.

## Measurements (256 KB ASCII doc, locked in by test)

| Entrypoint | `session_prepare_content_in_bytes` |
|---|---|
| `prepareSourceIngestion(String)`   | 256.1 KB |
| `prepareSourceIngestionFromUtf8`   | 256.1 KB (same FFI byte traffic; Dart heap saving is the win) |
| `prepareSourceIngestionFromFile`   | **0.0 KB** (body never crosses FFI) |

## Test plan

- [x] `cargo test --lib api::ingest_session` — 16 passed (8 new: UTF-8 valid/invalid/empty, from_file txt+md auto-strategy, missing path → IoError, counter regressions for both new entrypoints).
- [x] `cargo test --lib -- --test-threads=1` — 109 passed (parallel-mode failures in `hybrid_search` / `source_rag::assemble_context` exist on `main` from shared global state, unrelated).
- [x] `flutter test test/unit` — 55 passed.
- [x] `flutter test test/native` — 6 passed, including a new `from_utf8 / from_file deliver promised pass-through` test that runs `BenchmarkService.benchmarkIngestFfiEntrypoints` on a real Rust dylib and asserts the bytes-per-variant claim above.
- [x] `flutter analyze` — clean for changed files (two pre-existing example/ errors about `addDocumentBytes` are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)