### PR TITLE
feat: from_file ingest UX follow-up (fallback docs, example migration, body lengths)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,23 @@ class MySearchScreen extends StatelessWidget {
       name: 'notes.md',
     );
 
+    // File picker fallback: prefer the Rust-side file path fast path, but
+    // fall back when the selected document is not exposed as a stable local path.
+    try {
+      await MobileRag.instance.addDocumentFromFile(path, name: fileName);
+    } on RagError {
+      final bytes = await File(path).readAsBytes();
+      final lower = fileName.toLowerCase();
+      if (lower.endsWith('.txt') ||
+          lower.endsWith('.md') ||
+          lower.endsWith('.markdown')) {
+        await MobileRag.instance.addDocumentUtf8(bytes, name: fileName);
+      } else {
+        final text = await DocumentParser.parse(bytes);
+        await MobileRag.instance.addDocument(text, name: fileName);
+      }
+    }
+
     // Indexing is automatic! (Debounced 500ms)
     // Optional: await MobileRag.instance.rebuildIndex(); // Call if you want it done NOW
   

--- a/example/lib/services/rag_controller.dart
+++ b/example/lib/services/rag_controller.dart
@@ -1,7 +1,17 @@
+import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:mobile_rag_engine/mobile_rag_engine.dart';
+
+class _PickedImportResult {
+  final SourceAddResult addResult;
+  final int? textLength;
+
+  const _PickedImportResult({required this.addResult, this.textLength});
+}
 
 class RagController extends ChangeNotifier {
   String status = "Ready";
@@ -234,59 +244,11 @@ class RagController extends ChangeNotifier {
         return;
       }
 
-      status = "Reading file: ${file.name}";
-      notifyListeners();
-
-      String extractedText;
-      final ext = filePath.split('.').last.toLowerCase();
-
-      if (ext == 'md' || ext == 'markdown') {
-        extractedText = await File(filePath).readAsString();
-        status = "Markdown loaded! (${extractedText.length} chars)";
-        notifyListeners();
-      } else {
-        final bytes = await File(filePath).readAsBytes();
-        status = "Extracting text from ${file.name}...";
-        notifyListeners();
-        extractedText = await DocumentParser.parse(bytes.toList());
-      }
-
-      if (extractedText.isEmpty) {
-        _updateState("⚠️ No text extracted from file", newIsLoading: false);
+      final importResult = await _importPickedDocument(file, filePath);
+      if (importResult == null) {
         return;
       }
-
-      status =
-          "Text extracted! (${extractedText.length} chars)\nProcessing chunks...";
-      notifyListeners();
-
-      final addResult = _isDefaultCollection
-          ? await MobileRag.instance.addDocument(
-              extractedText,
-              metadata: '{"filename": "${file.name}"}',
-              name: file.name,
-              filePath: filePath,
-              onProgress: (done, total) {
-                if (done % 10 == 0 || done == total) {
-                  debugPrint('Embedding progress: $done/$total');
-                }
-                status = "Embedding chunks: $done/$total";
-                notifyListeners();
-              },
-            )
-          : await _activeCollection.addDocument(
-              extractedText,
-              metadata: '{"filename": "${file.name}"}',
-              name: "[$activeCollectionId] ${file.name}",
-              filePath: filePath,
-              onProgress: (done, total) {
-                if (done % 10 == 0 || done == total) {
-                  debugPrint('Embedding progress: $done/$total');
-                }
-                status = "Embedding chunks: $done/$total";
-                notifyListeners();
-              },
-            );
+      final addResult = importResult.addResult;
 
       if (addResult.isDuplicate) {
         if (addResult.chunkCount > 0) {
@@ -319,7 +281,7 @@ class RagController extends ChangeNotifier {
         _updateState(
           "✅ Document imported!\n"
           "📄 File: ${file.name}\n"
-          "📝 Text: ${extractedText.length} chars\n"
+          "${_formatImportedTextSummary(importResult)}\n"
           "📦 ${addResult.message}",
           newIsLoading: false,
         );
@@ -327,6 +289,173 @@ class RagController extends ChangeNotifier {
     } catch (e, st) {
       _updateState("❌ Import error: $e\n$st", newIsLoading: false);
     }
+  }
+
+  String _extensionFor(PlatformFile file, String filePath) {
+    final candidate = file.name.isNotEmpty ? file.name : filePath;
+    final dot = candidate.lastIndexOf('.');
+    if (dot < 0 || dot == candidate.length - 1) return '';
+    return candidate.substring(dot + 1).toLowerCase();
+  }
+
+  bool _isUtf8TextExtension(String extension) =>
+      extension == 'txt' || extension == 'md' || extension == 'markdown';
+
+  ChunkingStrategy? _strategyForExtension(String extension) {
+    if (extension == 'md' || extension == 'markdown') {
+      return ChunkingStrategy.markdown;
+    }
+    return null;
+  }
+
+  String _sourceNameForFile(String fileName) =>
+      _isDefaultCollection ? fileName : "[$activeCollectionId] $fileName";
+
+  String _formatImportedTextSummary(_PickedImportResult result) {
+    final textLength = result.textLength;
+    if (textLength != null) {
+      return "📝 Text: $textLength chars";
+    }
+    return "📝 Text: processed with low-memory file path";
+  }
+
+  void _onImportProgress(int done, int total) {
+    if (done % 10 == 0 || done == total) {
+      debugPrint('Embedding progress: $done/$total');
+    }
+    status = "Embedding chunks: $done/$total";
+    notifyListeners();
+  }
+
+  Future<SourceAddResult> _addFromFilePath({
+    required String filePath,
+    required String fileName,
+    required String metadata,
+    required ChunkingStrategy? strategy,
+  }) {
+    final name = _sourceNameForFile(fileName);
+    return _isDefaultCollection
+        ? MobileRag.instance.addDocumentFromFile(
+            filePath,
+            metadata: metadata,
+            name: name,
+            strategy: strategy,
+            onProgress: _onImportProgress,
+          )
+        : _activeCollection.addDocumentFromFile(
+            filePath,
+            metadata: metadata,
+            name: name,
+            strategy: strategy,
+            onProgress: _onImportProgress,
+          );
+  }
+
+  Future<SourceAddResult> _addUtf8Bytes({
+    required Uint8List bytes,
+    required String fileName,
+    required String metadata,
+    required ChunkingStrategy? strategy,
+  }) {
+    final name = _sourceNameForFile(fileName);
+    return _isDefaultCollection
+        ? MobileRag.instance.addDocumentUtf8(
+            bytes,
+            metadata: metadata,
+            name: name,
+            strategy: strategy,
+            onProgress: _onImportProgress,
+          )
+        : _activeCollection.addDocumentUtf8(
+            bytes,
+            metadata: metadata,
+            name: name,
+            strategy: strategy,
+            onProgress: _onImportProgress,
+          );
+  }
+
+  Future<SourceAddResult> _addExtractedText({
+    required String text,
+    required String filePath,
+    required String fileName,
+    required String metadata,
+  }) {
+    final name = _sourceNameForFile(fileName);
+    return _isDefaultCollection
+        ? MobileRag.instance.addDocument(
+            text,
+            metadata: metadata,
+            name: name,
+            filePath: filePath,
+            onProgress: _onImportProgress,
+          )
+        : _activeCollection.addDocument(
+            text,
+            metadata: metadata,
+            name: name,
+            filePath: filePath,
+            onProgress: _onImportProgress,
+          );
+  }
+
+  Future<_PickedImportResult?> _importPickedDocument(
+    PlatformFile file,
+    String filePath,
+  ) async {
+    final metadata = jsonEncode({'filename': file.name});
+    final extension = _extensionFor(file, filePath);
+    final strategy = _strategyForExtension(extension);
+
+    status = "Importing ${file.name} with file path fast path...";
+    notifyListeners();
+
+    try {
+      final addResult = await _addFromFilePath(
+        filePath: filePath,
+        fileName: file.name,
+        metadata: metadata,
+        strategy: strategy,
+      );
+      return _PickedImportResult(addResult: addResult);
+    } on RagError catch (e) {
+      debugPrint('File path ingest failed, falling back: $e');
+    }
+
+    final bytes = file.bytes ?? await File(filePath).readAsBytes();
+    if (_isUtf8TextExtension(extension)) {
+      status = "Falling back to UTF-8 ingest for ${file.name}...";
+      notifyListeners();
+      final addResult = await _addUtf8Bytes(
+        bytes: bytes,
+        fileName: file.name,
+        metadata: metadata,
+        strategy: strategy,
+      );
+      return _PickedImportResult(addResult: addResult);
+    }
+
+    status = "Extracting text from ${file.name}...";
+    notifyListeners();
+    final extractedText = await DocumentParser.parse(bytes.toList());
+    if (extractedText.isEmpty) {
+      _updateState("⚠️ No text extracted from file", newIsLoading: false);
+      return null;
+    }
+
+    status =
+        "Text extracted! (${extractedText.length} chars)\nProcessing chunks...";
+    notifyListeners();
+    final addResult = await _addExtractedText(
+      text: extractedText,
+      filePath: filePath,
+      fileName: file.name,
+      metadata: metadata,
+    );
+    return _PickedImportResult(
+      addResult: addResult,
+      textLength: extractedText.length,
+    );
   }
 
   Future<void> searchDocuments() async {

--- a/example/lib/services/rag_controller.dart
+++ b/example/lib/services/rag_controller.dart
@@ -312,7 +312,7 @@ class RagController extends ChangeNotifier {
       _isDefaultCollection ? fileName : "[$activeCollectionId] $fileName";
 
   String _formatImportedTextSummary(_PickedImportResult result) {
-    final textLength = result.textLength;
+    final textLength = result.addResult.bodyCharLength ?? result.textLength;
     if (textLength != null) {
       return "📝 Text: $textLength chars";
     }

--- a/example/lib/services/rag_controller.dart
+++ b/example/lib/services/rag_controller.dart
@@ -437,7 +437,7 @@ class RagController extends ChangeNotifier {
 
     status = "Extracting text from ${file.name}...";
     notifyListeners();
-    final extractedText = await DocumentParser.parse(bytes.toList());
+    final extractedText = await DocumentParser.parse(bytes);
     if (extractedText.isEmpty) {
       _updateState("⚠️ No text extracted from file", newIsLoading: false);
       return null;

--- a/lib/services/source_rag_service.dart
+++ b/lib/services/source_rag_service.dart
@@ -142,11 +142,22 @@ class SourceAddResult {
   final int chunkCount;
   final String message;
 
+  /// UTF-8 byte length of the text body after file parsing / decoding.
+  final int? bodyByteLength;
+
+  /// Text length as Dart `String.length` would report it (UTF-16 code units).
+  ///
+  /// This lets file-path ingest callers display the same "extracted text
+  /// length" style UI without materializing the full body in Dart.
+  final int? bodyCharLength;
+
   SourceAddResult({
     required this.sourceId,
     required this.isDuplicate,
     required this.chunkCount,
     required this.message,
+    this.bodyByteLength,
+    this.bodyCharLength,
   });
 }
 
@@ -586,6 +597,8 @@ class SourceRagService {
           isDuplicate: true,
           chunkCount: 0,
           message: prepared.message,
+          bodyByteLength: prepared.bodyByteLength,
+          bodyCharLength: prepared.bodyCharLength,
         );
       case rust_ingest.PreparedSourceState.duplicateInProgress:
         return SourceAddResult(
@@ -593,6 +606,8 @@ class SourceRagService {
           isDuplicate: true,
           chunkCount: 0,
           message: prepared.message,
+          bodyByteLength: prepared.bodyByteLength,
+          bodyCharLength: prepared.bodyCharLength,
         );
       case rust_ingest.PreparedSourceState.createdReady:
       case rust_ingest.PreparedSourceState.resumeReady:
@@ -654,6 +669,8 @@ class SourceRagService {
         isDuplicate: isResume,
         chunkCount: savedCount,
         message: isResume ? 'Source resumed and completed' : prepared.message,
+        bodyByteLength: prepared.bodyByteLength,
+        bodyCharLength: prepared.bodyCharLength,
       );
     } catch (e) {
       try {

--- a/lib/src/rust/api/ingest_session.dart
+++ b/lib/src/rust/api/ingest_session.dart
@@ -171,6 +171,8 @@ class PreparedIngestion {
   final PlatformInt64 sourceId;
   final PreparedSourceState state;
   final int totalChunks;
+  final int bodyByteLength;
+  final int bodyCharLength;
   final String message;
   final IngestSession? session;
 
@@ -178,6 +180,8 @@ class PreparedIngestion {
     required this.sourceId,
     required this.state,
     required this.totalChunks,
+    required this.bodyByteLength,
+    required this.bodyCharLength,
     required this.message,
     this.session,
   });
@@ -187,6 +191,8 @@ class PreparedIngestion {
       sourceId.hashCode ^
       state.hashCode ^
       totalChunks.hashCode ^
+      bodyByteLength.hashCode ^
+      bodyCharLength.hashCode ^
       message.hashCode ^
       session.hashCode;
 
@@ -198,6 +204,8 @@ class PreparedIngestion {
           sourceId == other.sourceId &&
           state == other.state &&
           totalChunks == other.totalChunks &&
+          bodyByteLength == other.bodyByteLength &&
+          bodyCharLength == other.bodyCharLength &&
           message == other.message &&
           session == other.session;
 }

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -5607,16 +5607,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PreparedIngestion dco_decode_prepared_ingestion(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 5)
-      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
     return PreparedIngestion(
       sourceId: dco_decode_i_64(arr[0]),
       state: dco_decode_prepared_source_state(arr[1]),
       totalChunks: dco_decode_i_32(arr[2]),
-      message: dco_decode_String(arr[3]),
+      bodyByteLength: dco_decode_i_32(arr[3]),
+      bodyCharLength: dco_decode_i_32(arr[4]),
+      message: dco_decode_String(arr[5]),
       session:
           dco_decode_opt_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerIngestSession(
-            arr[4],
+            arr[6],
           ),
     );
   }
@@ -6873,6 +6875,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_sourceId = sse_decode_i_64(deserializer);
     var var_state = sse_decode_prepared_source_state(deserializer);
     var var_totalChunks = sse_decode_i_32(deserializer);
+    var var_bodyByteLength = sse_decode_i_32(deserializer);
+    var var_bodyCharLength = sse_decode_i_32(deserializer);
     var var_message = sse_decode_String(deserializer);
     var var_session =
         sse_decode_opt_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerIngestSession(
@@ -6882,6 +6886,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       sourceId: var_sourceId,
       state: var_state,
       totalChunks: var_totalChunks,
+      bodyByteLength: var_bodyByteLength,
+      bodyCharLength: var_bodyCharLength,
       message: var_message,
       session: var_session,
     );
@@ -8115,6 +8121,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_i_64(self.sourceId, serializer);
     sse_encode_prepared_source_state(self.state, serializer);
     sse_encode_i_32(self.totalChunks, serializer);
+    sse_encode_i_32(self.bodyByteLength, serializer);
+    sse_encode_i_32(self.bodyCharLength, serializer);
     sse_encode_String(self.message, serializer);
     sse_encode_opt_AutoExplicit_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerIngestSession(
       self.session,

--- a/rust_builder/rust/src/api/ingest_session.rs
+++ b/rust_builder/rust/src/api/ingest_session.rs
@@ -63,6 +63,8 @@ pub struct PreparedIngestion {
     pub source_id: i64,
     pub state: PreparedSourceState,
     pub total_chunks: i32,
+    pub body_byte_length: i32,
+    pub body_char_length: i32,
     pub message: String,
     pub session: Option<RustAutoOpaque<IngestSession>>,
 }
@@ -449,6 +451,12 @@ fn prepare_source_ingestion_inner(
     max_chars: i32,
     overlap_chars: i32,
 ) -> Result<PreparedIngestion, RagError> {
+    let body_byte_length = content.len() as i32;
+    // Dart's String.length reports UTF-16 code units. Mirror that so callers
+    // can preserve existing "extracted text length" UI without materializing
+    // the body in Dart on file-path ingest.
+    let body_char_length = content.encode_utf16().count() as i32;
+
     // The guard suppresses legacy counter increments for the nested calls
     // (add_source_in_collection, semantic_chunk_with_overlap, markdown_chunk)
     // so a session-path run does not double-charge legacy counters.
@@ -478,6 +486,8 @@ fn prepare_source_ingestion_inner(
                     source_id,
                     state: PreparedSourceState::DuplicateSkip,
                     total_chunks: 0,
+                    body_byte_length,
+                    body_char_length,
                     message: add_result.message,
                     session: None,
                 });
@@ -487,6 +497,8 @@ fn prepare_source_ingestion_inner(
                     source_id,
                     state: PreparedSourceState::DuplicateInProgress,
                     total_chunks: 0,
+                    body_byte_length,
+                    body_char_length,
                     message: "Source ingestion already in progress".to_string(),
                     session: None,
                 });
@@ -499,6 +511,8 @@ fn prepare_source_ingestion_inner(
                         source_id,
                         state: PreparedSourceState::DuplicateInProgress,
                         total_chunks: 0,
+                        body_byte_length,
+                        body_char_length,
                         message: "Source ingestion already in progress".to_string(),
                         session: None,
                     });
@@ -561,6 +575,8 @@ fn prepare_source_ingestion_inner(
         source_id,
         state,
         total_chunks: total,
+        body_byte_length,
+        body_char_length,
         message: add_result.message,
         session: Some(RustAutoOpaque::new(IngestSession {
             source_id,

--- a/rust_builder/rust/src/api/ingest_session.rs
+++ b/rust_builder/rust/src/api/ingest_session.rs
@@ -63,7 +63,13 @@ pub struct PreparedIngestion {
     pub source_id: i64,
     pub state: PreparedSourceState,
     pub total_chunks: i32,
+    /// UTF-8 byte length of the decoded text body after parsing / decoding.
+    ///
+    /// For `from_file`, this may be non-zero even though
+    /// `SESSION_PREPARE_CONTENT_IN` remains zero: the former describes the
+    /// extracted text body, while the latter counts text bytes that crossed FFI.
     pub body_byte_length: i32,
+    /// Text length using Dart `String.length` semantics (UTF-16 code units).
     pub body_char_length: i32,
     pub message: String,
     pub session: Option<RustAutoOpaque<IngestSession>>,
@@ -451,11 +457,11 @@ fn prepare_source_ingestion_inner(
     max_chars: i32,
     overlap_chars: i32,
 ) -> Result<PreparedIngestion, RagError> {
-    let body_byte_length = content.len() as i32;
+    let body_byte_length = saturating_i32(content.len());
     // Dart's String.length reports UTF-16 code units. Mirror that so callers
     // can preserve existing "extracted text length" UI without materializing
     // the body in Dart on file-path ingest.
-    let body_char_length = content.encode_utf16().count() as i32;
+    let body_char_length = saturating_i32(content.encode_utf16().count());
 
     // The guard suppresses legacy counter increments for the nested calls
     // (add_source_in_collection, semantic_chunk_with_overlap, markdown_chunk)
@@ -587,6 +593,10 @@ fn prepare_source_ingestion_inner(
             state: SessionState::Draining,
         })),
     })
+}
+
+fn saturating_i32(value: usize) -> i32 {
+    i32::try_from(value).unwrap_or(i32::MAX)
 }
 
 // ---------------------------------------------------------------------------
@@ -724,6 +734,13 @@ mod tests {
     }
 
     #[test]
+    fn test_saturating_i32_caps_overflow() {
+        assert_eq!(saturating_i32(i32::MAX as usize), i32::MAX);
+        assert_eq!(saturating_i32(i32::MAX as usize + 1), i32::MAX);
+        assert_eq!(saturating_i32(usize::MAX), i32::MAX);
+    }
+
+    #[test]
     fn test_prepare_new_source_creates_ready_session() {
         let _guard = test_guard();
         let db_path = setup_test_db("test_ingest_prepare_new.db");
@@ -768,6 +785,8 @@ mod tests {
         let db_path = setup_test_db("test_ingest_prepare_dup_completed.db");
 
         let content = "Reusable document body.".to_string();
+        let expected_body_byte_length = content.len() as i32;
+        let expected_body_char_length = content.encode_utf16().count() as i32;
         // First ingest, finalize completed.
         let first = prepare_source_ingestion(
             "__default__".to_string(),
@@ -800,6 +819,8 @@ mod tests {
         assert_eq!(second.state, PreparedSourceState::DuplicateSkip);
         assert!(second.session.is_none());
         assert_eq!(second.source_id, first.source_id);
+        assert_eq!(second.body_byte_length, expected_body_byte_length);
+        assert_eq!(second.body_char_length, expected_body_char_length);
 
         teardown_test_db(db_path);
     }
@@ -1128,6 +1149,8 @@ mod tests {
         let db_path = setup_test_db("test_ingest_prepare_from_utf8_ok.db");
 
         let content = "Bytes path body. 한글 포함.".to_string();
+        let expected_body_byte_length = content.len() as i32;
+        let expected_body_char_length = content.encode_utf16().count() as i32;
         let prepared = prepare_source_ingestion_from_utf8(
             "__default__".to_string(),
             content.into_bytes(),
@@ -1141,6 +1164,8 @@ mod tests {
 
         assert_eq!(prepared.state, PreparedSourceState::CreatedReady);
         assert!(prepared.total_chunks >= 1);
+        assert_eq!(prepared.body_byte_length, expected_body_byte_length);
+        assert_eq!(prepared.body_char_length, expected_body_char_length);
         let session_opaque = prepared.session.unwrap();
         let mut session = session_opaque.blocking_write();
         let saved = drain_session_with_fake_embeddings(&mut session);
@@ -1200,6 +1225,8 @@ mod tests {
             PreparedSourceState::CreatedReady | PreparedSourceState::ResumeReady,
         ));
         assert_eq!(prepared.total_chunks, 0);
+        assert_eq!(prepared.body_byte_length, 0);
+        assert_eq!(prepared.body_char_length, 0);
         let session_opaque = prepared.session.unwrap();
         let mut session = session_opaque.blocking_write();
         session.finalize().unwrap();

--- a/rust_builder/rust/src/frb_generated.rs
+++ b/rust_builder/rust/src/frb_generated.rs
@@ -5722,12 +5722,16 @@ impl SseDecode for crate::api::ingest_session::PreparedIngestion {
         let mut var_state =
             <crate::api::ingest_session::PreparedSourceState>::sse_decode(deserializer);
         let mut var_totalChunks = <i32>::sse_decode(deserializer);
+        let mut var_bodyByteLength = <i32>::sse_decode(deserializer);
+        let mut var_bodyCharLength = <i32>::sse_decode(deserializer);
         let mut var_message = <String>::sse_decode(deserializer);
         let mut var_session = <Option<RustAutoOpaqueMoi<IngestSession>>>::sse_decode(deserializer);
         return crate::api::ingest_session::PreparedIngestion {
             source_id: var_sourceId,
             state: var_state,
             total_chunks: var_totalChunks,
+            body_byte_length: var_bodyByteLength,
+            body_char_length: var_bodyCharLength,
             message: var_message,
             session: var_session,
         };
@@ -7217,6 +7221,8 @@ impl flutter_rust_bridge::IntoDart for crate::api::ingest_session::PreparedInges
             self.source_id.into_into_dart().into_dart(),
             self.state.into_into_dart().into_dart(),
             self.total_chunks.into_into_dart().into_dart(),
+            self.body_byte_length.into_into_dart().into_dart(),
+            self.body_char_length.into_into_dart().into_dart(),
             self.message.into_into_dart().into_dart(),
             self.session.into_into_dart().into_dart(),
         ]
@@ -8216,6 +8222,8 @@ impl SseEncode for crate::api::ingest_session::PreparedIngestion {
         <i64>::sse_encode(self.source_id, serializer);
         <crate::api::ingest_session::PreparedSourceState>::sse_encode(self.state, serializer);
         <i32>::sse_encode(self.total_chunks, serializer);
+        <i32>::sse_encode(self.body_byte_length, serializer);
+        <i32>::sse_encode(self.body_char_length, serializer);
         <String>::sse_encode(self.message, serializer);
         <Option<RustAutoOpaqueMoi<IngestSession>>>::sse_encode(self.session, serializer);
     }

--- a/test/native/ingest_ffi_traffic_test.dart
+++ b/test/native/ingest_ffi_traffic_test.dart
@@ -1,7 +1,13 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_rag_engine/services/benchmark_service.dart';
+import 'package:mobile_rag_engine/src/rust/api/db_pool.dart';
+import 'package:mobile_rag_engine/src/rust/api/ingest_session.dart'
+    as ingest_session;
+import 'package:mobile_rag_engine/src/rust/api/simple_rag.dart';
+import 'package:mobile_rag_engine/src/rust/api/source_rag.dart' as source_rag;
 import 'package:mobile_rag_engine/src/rust/frb_generated.dart';
 
 Future<void> _ensureRustLoaded() async {
@@ -155,6 +161,50 @@ void main() {
       }
     },
   );
+
+  test('PreparedIngestion reports body byte and text lengths', () async {
+    final dir = await Directory.systemTemp.createTemp(
+      'mobile_rag_body_length_',
+    );
+    var poolOpen = false;
+    try {
+      final dbPath = '${dir.path}/body_length.sqlite';
+      await initDbPool(dbPath: dbPath, maxSize: 4);
+      poolOpen = true;
+      await initDb();
+      await source_rag.initSourceDb();
+
+      const text = '보험 약관 test 😀';
+      final file = File('${dir.path}/body.txt');
+      await file.writeAsString(text, flush: true);
+
+      final prepared = await ingest_session.prepareSourceIngestionFromFile(
+        collectionId: 'body-length',
+        filePath: file.path,
+        metadata: null,
+        name: 'body.txt',
+        strategyHint: ingest_session.IngestStrategy.recursive,
+        maxChars: 1500,
+        overlapChars: 0,
+      );
+
+      expect(prepared.bodyByteLength, utf8.encode(text).length);
+      expect(prepared.bodyCharLength, text.length);
+
+      final session = prepared.session;
+      if (session != null) {
+        await session.abort();
+        await session.dispose();
+      }
+    } finally {
+      if (poolOpen) {
+        try {
+          await closeDbPool();
+        } catch (_) {}
+      }
+      await dir.delete(recursive: true);
+    }
+  });
 
   test(
     'Peak-RSS delta: from_file < from_utf8 / string (heap pass-through)',


### PR DESCRIPTION
Post-merge follow-up to PRs #38/#40. Addresses the `from_file` UX gaps surfaced in review: fallback guidance, example app migration, body length reporting without materializing the body in Dart, and review fixes for the fallback memory path / length guards.

## Commits

1. `docs: show file ingest fallback pattern`
   - Adds README guidance for trying `addDocumentFromFile` first, then falling back to `addDocumentUtf8` for text-like files or `DocumentParser.parse` + `addDocument` for PDF/DOCX.

2. `example: use file ingest fast path with fallback`
   - Migrates `RagController.importAndEmbedDocument` to `addDocumentFromFile` first.
   - Preserves old behavior through helper paths for UTF-8 bytes and parsed text fallback.
   - Keeps collection-aware dispatch and Markdown strategy handling.

3. `feat: expose ingest body lengths`
   - Adds `body_byte_length` / `body_char_length` to Rust `PreparedIngestion` and generated FRB bindings.
   - Threads nullable `bodyByteLength` / `bodyCharLength` through `SourceAddResult`.
   - Lets the example preserve the old `N chars` UX on file-path ingest without creating a Dart body string.

4. `fix: tighten ingest body length follow-up`
   - Removes the fallback `bytes.toList()` copy before `DocumentParser.parse(bytes)`.
   - Uses saturating `usize -> i32` conversion for body lengths to avoid silent wrap.
   - Documents why `from_file` can have non-zero `body_byte_length` while FFI body traffic remains zero.
   - Extends Rust tests for `DuplicateSkip`, UTF-8 input, empty body, and overflow capping.

## Validation

- [x] `flutter analyze example/lib/services/rag_controller.dart`
- [x] `flutter analyze lib/services/source_rag_service.dart example/lib/services/rag_controller.dart test/native/ingest_ffi_traffic_test.dart`
- [x] `cargo test --manifest-path rust_builder/rust/Cargo.toml ingest_session -- --test-threads=1`
- [x] `cargo test --manifest-path rust_builder/rust/Cargo.toml -- --test-threads=1` — 110 passed, 1 ignored
- [x] `cargo build --release --manifest-path rust_builder/rust/Cargo.toml`
- [x] `flutter test test/native/ingest_ffi_traffic_test.dart --reporter compact` — 5/5 pass
- [x] `git diff --check`
- [x] CI green
