### PR TITLE
chore: prepare 0.18.2 release

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -28,6 +28,9 @@ artifacts/faer_int8_*
 # 빌드 산출물
 build/
 platform-build/
+doc/
+output/
+tmp/
 rust/target/
 rust/tests/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.18.2
+* **Ingest fast path**:
+  - Updated example/evaluation runners to use `addDocumentFromFile(...)` so PDF and asset-backed ingestion exercise the Rust-side file fast path instead of the removed byte-ingest compatibility call.
+  - Exposed extracted body byte/character lengths through `SourceAddResult` for file-path ingest UIs without materializing the full body in Dart.
+* **Compatibility**:
+  - Bumped dependency constraint to `rag_engine_flutter: ^0.18.1` because the body-length fields are part of the generated Rust FFI surface.
+* **Packaging**:
+  - Excluded generated docs and local scratch output directories from the published archive.
+
 ## 0.18.1
 * **Compatibility**:
   - Bumped dependency constraint to `rag_engine_flutter: ^0.18.0` so consumers actually receive the matching native release with the 0.18.0 retrieval hot-path optimizations. The 0.18.0 publish shipped with the prior `^0.17.0` constraint by mistake and resolved to `rag_engine_flutter 0.17.0` for new installs.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -206,7 +206,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.18.1"
+    version: "0.18.2"
   onnxruntime:
     dependency: transitive
     description:
@@ -293,7 +293,7 @@ packages:
       path: "../rust_builder"
       relative: true
     source: path
-    version: "0.18.0"
+    version: "0.18.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -479,10 +479,10 @@ packages:
     dependency: "direct main"
     description:
       name: rag_engine_flutter
-      sha256: "48d87a6dd53842fb4c58fe34efda5089e84dcdbbff3b2fd49f68bfe9253611d0"
+      sha256: ba65e620d2b825c4f23a801d1593df338e9a3e1d5b6239911364055c54590529
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.0"
+    version: "0.18.1"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_rag_engine
 description: A high-performance, on-device RAG (Retrieval-Augmented Generation) engine for Flutter. Run semantic search completely offline on iOS and Android with HNSW vector indexing.
-version: 0.18.1
+version: 0.18.2
 homepage: https://github.com/dev07060/mobile_rag_engine
 repository: https://github.com/dev07060/mobile_rag_engine
 issue_tracker: https://github.com/dev07060/mobile_rag_engine/issues
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_rust_bridge: ^2.11.1
-  rag_engine_flutter: ^0.18.0
+  rag_engine_flutter: ^0.18.1
   path_provider: ^2.1.5
   onnxruntime: ^1.4.1
   freezed_annotation: ^3.1.0

--- a/rust_builder/CHANGELOG.md
+++ b/rust_builder/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.18.1
+* **Ingest session**:
+  - Added extracted body byte/character lengths to `PreparedIngestion` so Dart file-ingest callers can display body-size metadata without materializing the full body.
+  - Kept `prepare_source_ingestion_from_file` on the path-only fast path: the extracted body is measured in Rust while document text still avoids Dart FFI body transfer.
+
 ## 0.18.0
 * **Retrieval hot path (copy-minimized Rust core)**:
   - Added `search_hnsw_slice(&[f32], usize)` and `search_hybrid_inner(String, &[f32], ...)` as borrowed-slice variants of the existing FFI-public entrypoints. The owned-`Vec<f32>` signatures of `search_hnsw` and `search_hybrid` are preserved for `flutter_rust_bridge` compatibility and now delegate to the slice helpers.

--- a/rust_builder/pubspec.yaml
+++ b/rust_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: rag_engine_flutter
 description: >
   Native Rust FFI plugin for mobile_rag_engine. Provides high-performance
   tokenization and HNSW vector indexing for on-device RAG.
-version: 0.18.0
+version: 0.18.1
 homepage: https://github.com/dev07060/mobile_rag_engine
 repository: https://github.com/dev07060/mobile_rag_engine
 issue_tracker: https://github.com/dev07060/mobile_rag_engine/issues

--- a/test/unit/context_builder_regression_test.dart
+++ b/test/unit/context_builder_regression_test.dart
@@ -260,7 +260,7 @@ void main() {
     test(
       'deriveContextBudgetForPrompt can use a target prompt token counter',
       () {
-        final counter = (String text) => RegExp(r'\S+').allMatches(text).length;
+        int counter(String text) => RegExp(r'\S+').allMatches(text).length;
         const query = 'Where is the guide?';
         final expectedSkeleton = 'Answer the question based ONLY on the '
             'documents below. If the information is not in the documents, '


### PR DESCRIPTION
## Summary
- publish metadata for rag_engine_flutter 0.18.1 and mobile_rag_engine 0.18.2
- update dependency locks to rag_engine_flutter 0.18.1
- exclude generated/local scratch directories from package archive
- clear the analyzer lint in context builder regression coverage

## Validation
- flutter analyze
- dart pub publish --dry-run
- published rag_engine_flutter 0.18.1
- published mobile_rag_engine 0.18.2