### PR TITLE
Publish mobile_rag_engine 0.18.3 docs update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.18.3
+* **Documentation**:
+  - Removed the oversized README memory benchmark note from the top of the pub.dev page.
+  - Aligned guide and example snippets with the current `MobileRag` facade and file-path ingest APIs.
+  - Fixed stale example model download URLs and clarified the supported platform/documentation release guidance.
+
 ## 0.18.2
 * **Ingest fast path**:
   - Updated example/evaluation runners to use `addDocumentFromFile(...)` so PDF and asset-backed ingestion exercise the Rust-side file fast path instead of the removed byte-ingest compatibility call.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -53,6 +53,10 @@ flutter pub publish --dry-run
 
 The root package should only bump its `rag_engine_flutter` dependency after the matching native package version is available on pub.dev. This keeps CI and package resolution valid between the two releases.
 
+### Public Documentation Guard
+
+README and other public-facing documentation changes should be reviewed as their own release scope. Do not fold incidental README rewrites into a publish commit unless the release explicitly includes public documentation updates.
+
 ## Troubleshooting
 
 ### Error: "Content hash on Dart side is different from Rust side"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Production-ready, fully local RAG (Retrieval-Augmented Generation) engine for Flutter.**
 
-Powered by a **Rust core**, it delivers lightning-fast vector search and embedding generation directly on the device. No servers, no API costs, no latency.
+Powered by a **Rust core**, it runs vector search and embedding generation directly on the device. No servers, no API costs, no network round-trips.
 
 ---
 
@@ -24,9 +24,11 @@ This package includes **pre-compiled binaries** for iOS, Android, and macOS. Jus
 
 | Feature | Pure Dart | **Mobile RAG Engine (Rust)** |
 |:---|:---:|:---:|
-| **Tokenization** | Slow | **10x Faster** (HuggingFace tokenizers) |
-| **Vector Search** | O(n) | **O(log n)** (HNSW Index) |
-| **Memory Usage** | High | **Optimized** (copy-minimized Rust core) |
+| **Tokenization** | Slow | HuggingFace `tokenizers` (Rust) |
+| **Vector Search** | O(n) | HNSW Index — sub-linear retrieval |
+| **Memory Usage** | High | Copy-minimized Rust core, `Float32List` zero-copy transport |
+
+> Numbers vary by device and corpus. See [`benchmark_service`](https://github.com/dev07060/mobile_rag_engine/blob/main/lib/services/benchmark_service.dart) and the `0.18.0` retrieval-hot-path notes in [CHANGELOG.md](https://github.com/dev07060/mobile_rag_engine/blob/main/CHANGELOG.md) for measured deltas on your own hardware.
 
 ### 100% Offline & Private
 
@@ -97,31 +99,31 @@ curl -L -o tokenizer.json "https://huggingface.co/sentence-transformers/all-Mini
 ## Quick Index
 
 ### Features
-*   [Adjacent Chunk Retrieval](docs/features/adjacent_chunk_retrieval.md) - Fetch surrounding context.
-*   [Index Management](docs/features/index_management.md) - Stats, persistence, and recovery.
-*   [Markdown Chunker](docs/features/markdown_chunker.md) - Structure-aware text splitting.
-*   [Multi-Collection](docs/features/multi_collection.md) - Isolate ingest/search/rebuild by category.
-*   [Prompt Compression](docs/features/prompt_compression.md) - Reduce token usage.
-*   [Search by Source](docs/features/search_by_source.md) - Filter results by document.
-*   [Search Strategies](docs/features/search_strategies.md) - Tune ranking and retrieval.
+*   [Adjacent Chunk Retrieval](https://github.com/dev07060/mobile_rag_engine/blob/main/docs/features/adjacent_chunk_retrieval.md) - Fetch surrounding context.
+*   [Index Management](https://github.com/dev07060/mobile_rag_engine/blob/main/docs/features/index_management.md) - Stats, persistence, and recovery.
+*   [Markdown Chunker](https://github.com/dev07060/mobile_rag_engine/blob/main/docs/features/markdown_chunker.md) - Structure-aware text splitting.
+*   [Multi-Collection](https://github.com/dev07060/mobile_rag_engine/blob/main/docs/features/multi_collection.md) - Isolate ingest/search/rebuild by category.
+*   [Prompt Compression](https://github.com/dev07060/mobile_rag_engine/blob/main/docs/features/prompt_compression.md) - Reduce token usage.
+*   [Search by Source](https://github.com/dev07060/mobile_rag_engine/blob/main/docs/features/search_by_source.md) - Filter results by document.
+*   [Search Strategies](https://github.com/dev07060/mobile_rag_engine/blob/main/docs/features/search_strategies.md) - Tune ranking and retrieval.
 
 ### Guides
-*   [Quick Start](docs/guides/quick_start.md) - Setup in 5 minutes.
-*   [Model Setup](docs/guides/model_setup.md) - Choosing and downloading models.
-*   [Release Build](docs/guides/release_build.md) - Bundle size optimization for production.
-*   [Troubleshooting](docs/guides/troubleshooting.md) - Common fixes.
-*   [FAQ](docs/guides/faq.md) - Frequently asked questions.
+*   [Quick Start](https://github.com/dev07060/mobile_rag_engine/blob/main/docs/guides/quick_start.md) - Setup in 5 minutes.
+*   [Model Setup](https://github.com/dev07060/mobile_rag_engine/blob/main/docs/guides/model_setup.md) - Choosing and downloading models.
+*   [Release Build](https://github.com/dev07060/mobile_rag_engine/blob/main/docs/guides/release_build.md) - Bundle size optimization for production.
+*   [Troubleshooting](https://github.com/dev07060/mobile_rag_engine/blob/main/docs/guides/troubleshooting.md) - Common fixes.
+*   [FAQ](https://github.com/dev07060/mobile_rag_engine/blob/main/docs/guides/faq.md) - Frequently asked questions.
 
 ### Testing
-*   [Unit Testing](docs/test/unit_testing.md) - Mocking for isolated tests.
+*   [Unit Testing](https://github.com/dev07060/mobile_rag_engine/blob/main/docs/test/unit_testing.md) - Mocking for isolated tests.
 
 ---
 
-Initialize the engine once in your `main()` function:
+## Usage
 
+### Minimal Setup
 
-
-### Initialization Parameters 
+Initialize the engine once in your `main()` function. See the [Quick Start Guide](https://github.com/dev07060/mobile_rag_engine/blob/main/docs/guides/quick_start.md#step-3-initialize) for the full parameter table.
 
 ```dart
 await MobileRag.initialize(
@@ -130,60 +132,55 @@ await MobileRag.initialize(
   deferIndexWarmup: true,
 );
 
-// Before first search:
+// Before first search, wait for BM25/HNSW warmup if you deferred it:
 if (!MobileRag.instance.isIndexReady) {
   await MobileRag.instance.warmupFuture;
 }
 ```
 
-Then use it anywhere in your app:
+### Adding Documents and Searching
 
 ```dart
 class MySearchScreen extends StatelessWidget {
   Future<void> _search() async {
-    // 2. Add Documents (auto-chunked & embedded)
+    // 1. Add Documents (auto-chunked & embedded). Indexing is auto-managed
+    //    (debounced ~500ms) — only call rebuildIndex() if you need it now.
     await MobileRag.instance.addDocument(
       'Flutter is a UI toolkit for building apps.',
     );
-    await MobileRag.instance.addDocument(
-      'Dart is the language used to build Flutter apps.',
-    );
 
-    // File/UTF-8 fast paths are useful for large local documents.
+    // File / UTF-8 fast paths are useful for large local documents.
     await MobileRag.instance.addDocumentFromFile('/path/to/manual.pdf');
     final noteBytes = await File('/path/to/notes.md').readAsBytes();
-    await MobileRag.instance.addDocumentUtf8(
-      noteBytes,
-      name: 'notes.md',
-    );
+    await MobileRag.instance.addDocumentUtf8(noteBytes, name: 'notes.md');
 
-    // File picker fallback: prefer the Rust-side file path fast path, but
-    // fall back when the selected document is not exposed as a stable local path.
-    try {
-      await MobileRag.instance.addDocumentFromFile(path, name: fileName);
-    } on RagError {
-      final bytes = await File(path).readAsBytes();
-      final lower = fileName.toLowerCase();
-      if (lower.endsWith('.txt') ||
-          lower.endsWith('.md') ||
-          lower.endsWith('.markdown')) {
-        await MobileRag.instance.addDocumentUtf8(bytes, name: fileName);
-      } else {
-        final text = await DocumentParser.parse(bytes);
-        await MobileRag.instance.addDocument(text, name: fileName);
-      }
-    }
-
-    // Indexing is automatic! (Debounced 500ms)
-    // Optional: await MobileRag.instance.rebuildIndex(); // Call if you want it done NOW
-  
-    // 3. Search with LLM-ready context
+    // 2. Search with LLM-ready context
     final result = await MobileRag.instance.search(
-      'What is Flutter?', 
+      'What is Flutter?',
       tokenBudget: 2000,
     );
-    
     print(result.context.text); // Ready to send to LLM
+  }
+}
+```
+
+### Handling File Picker Fallback
+
+`addDocumentFromFile` is the fastest path because the Rust core reads and chunks the file directly. Some platform pickers (cloud-backed pickers, content URIs without a stable local path, etc.) return data that is not exposed as a real filesystem path. In those cases, fall back to UTF-8 or parsed-text ingestion:
+
+```dart
+try {
+  await MobileRag.instance.addDocumentFromFile(path, name: fileName);
+} on RagError {
+  final bytes = await File(path).readAsBytes();
+  final lower = fileName.toLowerCase();
+  if (lower.endsWith('.txt') ||
+      lower.endsWith('.md') ||
+      lower.endsWith('.markdown')) {
+    await MobileRag.instance.addDocumentUtf8(bytes, name: fileName);
+  } else {
+    final text = await DocumentParser.parse(bytes);
+    await MobileRag.instance.addDocument(text, name: fileName);
   }
 }
 ```
@@ -266,4 +263,4 @@ Bug reports, feature requests, and PRs are all welcome!
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE).
+This project is licensed under the [MIT License](https://github.com/dev07060/mobile_rag_engine/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -10,20 +10,6 @@
 
 Powered by a **Rust core**, it delivers lightning-fast vector search and embedding generation directly on the device. No servers, no API costs, no latency.
 
-> **Memory note:** The embedding vector path is copy-minimized in 0.18.0 with `Float32List` and isolate transfer optimizations, and the Rust core avoids unnecessary copies. The ingest text pipeline now keeps chunk content resident in Rust between chunking and DB commit — one `addDocument(content)` call sends the document body across FFI **~2× document size** (down from ~4× under the pre-IngestSession chain). Verified by `BenchmarkService.benchmarkIngestFfiTraffic` and `test/native/ingest_ffi_traffic_test.dart`: 256 KB doc → legacy 1019 KB / IngestSession 510 KB / 50% reduction.
->
-> `addDocumentUtf8(bytes)` and `addDocumentFromFile(path)` are now true Rust-side bytes pass-through entrypoints (Rust functions `prepareSourceIngestionFromUtf8` / `prepareSourceIngestionFromFile`): UTF-8 bytes go straight into Rust without an intermediate Dart `String`, and the file variant reads the body inside Rust so it **never crosses FFI at all**. Public `addDocument(String)`, `addDocumentUtf8(bytes)`, and `addDocumentFromFile(path)` signatures are unchanged.
->
-> Measurements locked in by `test/native/ingest_ffi_traffic_test.dart` (verified on macOS dev host, ASCII bench corpus):
->
-> | Metric | `addDocument(String)` | `addDocumentUtf8(bytes)` | `addDocumentFromFile(path)` |
-> |---|---|---|---|
-> | FFI body bytes (256 KB doc) | 256.1 KB | 256.1 KB | **0.0 KB** |
-> | Peak RSS Δ (4 MB doc, full-process) | ~97 MB | ~17 MB | **~5 MB** |
-> | Wall-clock p50 (1 MB doc, stub embeddings) | 173.7 ms | 166.2 ms | **162.4 ms** |
->
-> The String path holds the full body in Dart memory plus chunker / staging intermediates before crossing FFI; the file path lets Rust read and chunk the body without ever materializing it in Dart, so peak RSS stays roughly an order of magnitude lower. Wall-clock gains are modest with stub embeddings (ONNX dominates real-world latency), but the heap and FFI-traffic gains compound on memory-constrained mobile devices.
-
 ---
 
 ## Why this package?
@@ -257,7 +243,7 @@ print(travelHits.length);
 If you do not specify a collection, the engine uses the default `__default__`
 collection for backward compatibility.
 
-> **Advanced Usage:** For fine-grained control, use the high-level metadata lane (`searchMeta`, `assembleContext`, `hydrateChunks`, `getChunkExcerpts`) or service APIs such as `EmbeddingService` and `SourceRagService` directly. See the [API Reference](https://pub.dev/documentation/mobile_rag_engine/latest/).
+> **Advanced Usage:** For fine-grained control, use the high-level metadata lane (`searchMeta`, `assembleContext`, `hydrateChunks`, `getChunkExcerpts`) and the public API reference. Most apps should stay on the `MobileRag` facade.
 
 
 ---

--- a/docs/features/adjacent_chunk_retrieval.md
+++ b/docs/features/adjacent_chunk_retrieval.md
@@ -47,7 +47,7 @@ final currentIndex = chunk.chunkIndex; // The sequential index of this chunk in 
 
 ### Fetching Neighbors
 
-You can access the low-level `service` to call `getAdjacentChunks`.
+Use `getAdjacentChunks` when you already have a source ID and chunk index.
 
 ```dart
 // 1. Calculate the range you want
@@ -55,8 +55,8 @@ You can access the low-level `service` to call `getAdjacentChunks`.
 final minIndex = (currentIndex - 2).clamp(0, 999999);
 final maxIndex = currentIndex + 2;
 
-// 2. Call the service
-final neighbors = await MobileRag.instance.engine.service.getAdjacentChunks(
+// 2. Fetch adjacent chunks
+final neighbors = await MobileRag.instance.getAdjacentChunks(
   sourceId: currentSourceId,
   minIndex: minIndex,
   maxIndex: maxIndex,

--- a/docs/features/index_management.md
+++ b/docs/features/index_management.md
@@ -38,7 +38,7 @@ await MobileRag.instance.removeSource(sourceId);
 
 ## 3. Data Migration & Re-embedding
 
-If you update your embedding model (e.g., switch from a 384-dim model to a 512-dim model), existing vectors become invalid. Mobile RAG Engine provides a utility to **re-calculate embeddings** for all existing chunks without re-parsing original files.
+If you update your embedding model (e.g., switch from a 384-dim model to a 512-dim model), existing vectors become invalid. The advanced `RagEngine` API provides a utility to **re-calculate embeddings** for all existing chunks without re-parsing original files.
 
 ```dart
 // Run this after initializing the engine with a NEW model

--- a/docs/features/markdown_chunker.md
+++ b/docs/features/markdown_chunker.md
@@ -63,12 +63,12 @@ If you need extra table context for later chunks, treat it as a retrieval/render
 ## Usage
 
 ### Automatic (Recommended)
-When you use `RagEngine` to add a document, the chunker is automatically applied if you provide the correct file path extension (`.md`).
+When you add a Markdown file through `MobileRag`, the chunker is automatically applied if the file path extension is `.md` or `.markdown`.
 
 ```dart
-await MobileRag.instance.addDocument(
-  filePath: '/path/to/guide.md',
-  // The engine automatically detects .md and uses the markdown chunker
+await MobileRag.instance.addDocumentFromFile(
+  '/path/to/guide.md',
+  name: 'guide.md',
 );
 ```
 
@@ -106,7 +106,7 @@ for (final chunk in chunks) {
 - Raw markdown chunk `content` is preserved as extracted text. Header path is **not** automatically prepended to stored content.
 - `headerPath` is carried separately and injected into embedding/context rendering paths.
 - Split table chunks preserve row boundaries, but later chunks do **not** receive a synthetic repeated header row.
-- `tokenBudget` applies to the assembled `context.text`, not the full prompt wrapper that `formatForPrompt()` adds later.
+- `tokenBudget` applies to the assembled `context.text`, not the full prompt wrapper that `formatPrompt()` adds later.
 
 ## Comparisons
 <p align="center">

--- a/docs/features/markdown_chunker.md
+++ b/docs/features/markdown_chunker.md
@@ -85,7 +85,7 @@ final markdownText = """
 
 // Chunk the markdown
 final chunks = await TextChunker.markdown(
-  text: markdownText,
+  markdownText,
   maxChars: 512, // Target chunk size
 );
 

--- a/docs/features/prompt_compression.md
+++ b/docs/features/prompt_compression.md
@@ -13,16 +13,17 @@ Mobile RAG Engine includes a built-in **Prompt Compressor** inspired by REFRAG p
 The easiest way to use compression is via `ContextBuilder.buildWithCompression`.
 
 ```dart
-final results = await MobileRag.instance.search('query');
+final result = await MobileRag.instance.search('query');
+final originalContext = result.context;
 
 // Build context with compression
 final context = await ContextBuilder.buildWithCompression(
-  searchResults: results.chunks,
+  searchResults: result.chunks,
   tokenBudget: 1000, // Stricter budget
   compressionLevel: 1, // Balanced
 );
 
-print('Original: ${context.text.length} chars');
+print('Original: ${originalContext.text.length} chars');
 print('Compressed: ${context.text.length} chars');
 ```
 
@@ -43,10 +44,11 @@ For advanced use cases, you can use the **Semantic Sentence Selector**. This bre
 ```dart
 // 1. Get query embedding
 final queryEmb = await EmbeddingService.embed('What is the battery life?');
+final result = await MobileRag.instance.search('battery life');
 
 // 2. Compress by selecting top 15 relevant sentences
 final compressed = await PromptCompressor.compressWithSimilarity(
-  chunks: searchResults,
+  chunks: result.chunks,
   queryEmbedding: queryEmb,
   maxSentences: 15,
   minSimilarity: 0.3,

--- a/docs/features/search_strategies.md
+++ b/docs/features/search_strategies.md
@@ -55,7 +55,7 @@ final result = await MobileRag.instance.searchHybridWithContext(
 - **Default**: `2000`
 - **Description**: The maximum number of **engine tokenizer** tokens the final `context.text` string can contain.
 - **Counting basis**: document wrappers, metadata, and markdown header-path contextual text are included in this count because the engine measures the fully rendered context string.
-- **Scope note**: This budget applies to `context.text` only. It does **not** automatically include the extra system instruction, question, or answer wrapper added later by `formatForPrompt()`.
+- **Scope note**: This budget applies to `context.text` only. It does **not** automatically include the extra system instruction, question, or answer wrapper added later by `formatPrompt()`.
 - **Tip**: Set this based on your LLM's context window minus your prompt size. (e.g., for 4k model, use ~3000).
 
 ### `adjacentChunks`

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -60,7 +60,7 @@ Supported ONNX required inputs:
 Not supported yet:
 - Models requiring extra mandatory inputs such as `position_ids`
 
-Officially validated ONNX artifacts (0.14.x):
+Validated ONNX artifacts:
 - `https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_qint8_arm64.onnx`
 - `https://huggingface.co/Teradata/bge-m3/resolve/main/onnx/model_int8.onnx`
 
@@ -77,7 +77,7 @@ optimum-cli export onnx --model sentence-transformers/YOUR_MODEL --task feature-
 - BGE-m3: 1024 dimensions
 - MiniLM: 384 dimensions
 
-From `0.14.x` hardening patches, runtime now fails fast on dimension mismatch with a clear error (`expected/got`).
+Current releases fail fast on dimension mismatch with a clear error (`expected/got`). This behavior was introduced in the `0.14.x` hardening patches.
 After model replacement, run either:
 - clear/rebuild flow
 - `regenerateAllEmbeddings()`
@@ -90,13 +90,13 @@ After model replacement, run either:
 
 1. **Use batch processing**:
    ```dart
-   await EmbeddingService.embedBatch(texts, onProgress: ...);
+   await EmbeddingService.embedBatch(
+     texts,
+     onProgress: (done, total) => print('$done / $total'),
+   );
    ```
 
-2. **Run in isolate** (prevents UI freezing):
-   ```dart
-   await compute(embedInBackground, texts);
-   ```
+2. **Keep embedding off the UI thread**: `MobileRag.initialize(...)` configures the embedding worker isolate for normal app flows.
 
 3. **Use INT8 quantized models** - 2-4x faster
 
@@ -109,9 +109,11 @@ await MobileRag.instance.rebuildIndex();
 
 ### Q: Memory usage is high
 
-- **Limit document count**: 10K+ may cause degradation
-- **Use INT8 models**: 50% memory savings
-- **Rebuild index periodically**: Call `MobileRag.instance.rebuildIndex()`
+- **Prefer file-path ingest for large local files**: Use `addDocumentFromFile(path)` for PDF, DOCX, Markdown, and text files when you have a stable path.
+- **Use UTF-8 ingest when bytes are already loaded**: Use `addDocumentUtf8(bytes)` for text/Markdown bytes instead of converting them to a Dart `String` first.
+- **Limit document count**: 10K+ may cause degradation.
+- **Use INT8 models**: Smaller models reduce memory pressure.
+- **Rebuild index periodically**: Call `MobileRag.instance.rebuildIndex()` when you need deterministic index freshness.
 
 ### Q: Which dispose API should I use?
 

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -170,15 +170,17 @@ Currently supports **iOS, Android, and macOS** only. Web support is planned for 
 ### Q: Where is data stored?
 
 In the Documents directory as a SQLite database (via `path_provider`):
-- iOS: `~/Documents/rag.db`
-- Android: `/data/data/<package>/files/rag.db`
+- iOS: `~/Documents/rag.sqlite`
+- Android: `/data/data/<package>/files/rag.sqlite`
+
+> The default filename is `rag.sqlite`. Override it via `databaseName:` when calling `MobileRag.initialize`.
 
 ### Q: Can I backup/restore data?
 
-Copy the database file (`rag.db`):
+Copy the database file (`rag.sqlite`):
 
 ```dart
-final dbFile = File('${dir.path}/rag.db');
+final dbFile = File('${dir.path}/rag.sqlite');
 await dbFile.copy(backupPath);
 ```
 

--- a/docs/guides/model_setup.md
+++ b/docs/guides/model_setup.md
@@ -13,14 +13,14 @@ This guide covers embedding model selection, download, and deployment strategies
 
 > **Dimension Matters**: The embedding dimension affects your vector index. Once you choose a model, all documents must use the same dimension. Switching models requires re-embedding all documents.
 
-### Officially Validated ONNX Artifacts (0.14.x)
+### Validated ONNX Artifacts
 
 - MiniLM: `https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model_qint8_arm64.onnx`
 - BGE-m3: `https://huggingface.co/Teradata/bge-m3/resolve/main/onnx/model_int8.onnx`
 
 These are the regression-tested artifacts for each patch release.
 
-Compatibility was expanded in 0.14.x patches:
+Compatibility improvements introduced in the `0.14.x` hardening patches remain available in current releases:
 - models requiring `token_type_ids` are now supported without re-export
 - the engine reads ONNX `inputNames` and injects zero `token_type_ids` only when required
 
@@ -166,7 +166,10 @@ This package uses the [`onnxruntime`](https://pub.dev/packages/onnxruntime) Flut
 1. **Use INT8 quantized models** - 2-4x smaller, similar accuracy
 2. **Batch embeddings** when processing many documents:
    ```dart
-   await EmbeddingService.embedBatch(texts, onProgress: (i, n) => ...);
+   await EmbeddingService.embedBatch(
+     texts,
+     onProgress: (done, total) => print('$done / $total'),
+   );
    ```
 3. **Run in isolate** for heavy processing to avoid UI jank
 

--- a/docs/guides/quick_start.md
+++ b/docs/guides/quick_start.md
@@ -111,11 +111,16 @@ await MobileRag.instance.addDocument(
   'Flutter is Google\'s UI toolkit for building beautiful apps.',
 );
 
-// Add PDF/DOCX
-// See [Markdown Chunker](../features/markdown_chunker.md) for structural handling
-final bytes = await File('document.pdf').readAsBytes();
-final text = await DocumentParser.parse(bytes.toList());
-await MobileRag.instance.addDocument(text, filePath: 'document.pdf');
+// Add PDF/DOCX or other local files by path.
+// This lets Rust read and chunk the file directly.
+await MobileRag.instance.addDocumentFromFile(
+  'document.pdf',
+  name: 'document.pdf',
+);
+
+// If a stable local path is not available, fall back to bytes/text ingestion.
+final bytes = await File('notes.md').readAsBytes();
+await MobileRag.instance.addDocumentUtf8(bytes, name: 'notes.md');
 
 // Optional: force immediate rebuild if you need deterministic timing.
 // In most apps this is not required because indexing is auto-managed.
@@ -146,12 +151,12 @@ for (final chunk in result.chunks) {
 ```
 
 Notes:
-- `tokenBudget` is measured against `context.text`, not the full prompt wrapper added by `formatForPrompt()`.
+- `tokenBudget` is measured against `context.text`, not the full prompt wrapper added by `formatPrompt()`.
 - In compressed paths, `includedChunks` represents source provenance for the compressed context, not a 1:1 segment map of the final compressed text.
 
 ---
 
-## Step 6: Source-Filtered Search (New!)
+## Step 6: Source-Filtered Search
 
 You can search within specific documents using `searchHybrid` with `sourceIds`. See [Search by Source](../features/search_by_source.md) for full guide.
 
@@ -246,7 +251,7 @@ For fine-grained control, you can still use the low-level APIs:
 
 ```dart
 // Use services directly for custom flows
-final text = await DocumentParser.parsePdf(pdfBytes);
+final text = await DocumentParser.parse(pdfBytes);
 final intent = IntentParser.classify('Summarize this');
 ```
 

--- a/docs/guides/release_build.md
+++ b/docs/guides/release_build.md
@@ -14,13 +14,24 @@ The ONNX embedding model is the single largest contributor to your app's downloa
 | BGE-m3 (INT8) | ~542 MB | **Exceeds Play Store 150 MB limit** |
 
 **For development**, bundle the model in `assets/` for quick iteration.
-**For production releases**, download the model at runtime to keep your bundle small:
+**For production releases**, download the model at runtime to keep your bundle small.
+
+`MobileRag.initialize` only accepts asset paths today (`tokenizerAsset`, `modelAsset`), but the engine resolves `modelAsset` to `<appDocumentsDirectory>/<basename>` and skips the asset copy if that file already exists. You can use this to ship without the model in your bundle:
 
 ```dart
-// Initialize with a file path instead of an asset path
+// 1. Before initialize, write the downloaded model to the destination filename
+//    used by MobileRag (matches the basename of modelAsset).
+final dir = await getApplicationDocumentsDirectory();
+final modelFile = File('${dir.path}/model.onnx');
+if (!await modelFile.exists()) {
+  await downloadModel(modelFile); // your CDN / Hugging Face fetch
+}
+
+// 2. Initialize as usual. The asset copy is skipped because the file exists.
+//    Do NOT list assets/model.onnx in pubspec.yaml when shipping this flow.
 await MobileRag.initialize(
-  tokenizerAsset: 'assets/tokenizer.json',  // small (~750KB), safe to bundle
-  modelPath: '${appDocDir.path}/model.onnx', // downloaded at runtime
+  tokenizerAsset: 'assets/tokenizer.json', // small (~750KB), safe to bundle
+  modelAsset: 'assets/model.onnx',         // basename only is significant here
 );
 ```
 

--- a/docs/guides/release_build.md
+++ b/docs/guides/release_build.md
@@ -43,7 +43,7 @@ The following are bundled automatically and cannot be removed:
 
 ## pdfrx Users
 
-If your app uses [`pdfrx`](https://pub.dev/packages/pdfrx) for PDF rendering, it bundles a `pdfium.wasm` file (~2 MB) intended for web builds. This is unnecessary in native release builds.
+This package does not require `pdfrx`. If your app also uses [`pdfrx`](https://pub.dev/packages/pdfrx) for PDF rendering, it bundles a `pdfium.wasm` file (~2 MB) intended for web builds. This is unnecessary in native release builds.
 
 Remove it before building:
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -73,10 +73,12 @@ OnnxRuntimeException: Failed to create session
 - [ ] Verify model is compatible with ONNX Runtime
 
 ```dart
-// Verify file exists
-final file = File(modelPath);
+// The engine copies modelAsset to <appDocumentsDirectory>/<basename>.
+// Verify the resolved file the engine actually loads.
+final dir = await getApplicationDocumentsDirectory();
+final file = File('${dir.path}/model.onnx');
 if (!await file.exists()) {
-  throw Exception('Model file not found: $modelPath');
+  throw Exception('Model file not found at expected path: ${file.path}');
 }
 
 // Verify file size (corruption check)

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -38,17 +38,22 @@ Exception: Failed to initialize tokenizer
 
 | Cause | Solution |
 |:------|:---------|
-| Wrong file path | Use absolute path |
+| Asset path not registered | Add the tokenizer to `pubspec.yaml` assets and pass the same asset path |
 | Wrong file format | Must be HuggingFace `tokenizer.json` (not SentencePiece) |
 | Corrupted file | Re-download |
 
 ```dart
-// ✅ Correct: absolute path
-final dir = await getApplicationDocumentsDirectory();
-await initTokenizer(tokenizerPath: '${dir.path}/tokenizer.json');
+// Correct: use the asset path registered in pubspec.yaml.
+await MobileRag.initialize(
+  tokenizerAsset: 'assets/tokenizer.json',
+  modelAsset: 'assets/model.onnx',
+);
 
-// ❌ Wrong: relative path
-await initTokenizer(tokenizerPath: 'assets/tokenizer.json');
+// Wrong: passing a filesystem path as tokenizerAsset.
+await MobileRag.initialize(
+  tokenizerAsset: '/tmp/tokenizer.json',
+  modelAsset: 'assets/model.onnx',
+);
 ```
 
 ---
@@ -94,7 +99,7 @@ Missing Input: token_type_ids
 **Cause:** The ONNX model requires `token_type_ids` as a mandatory input.
 
 **Solution:**
-1. Update to the latest `0.14.x` patch (`>=0.14.2`), which auto-fills zero `token_type_ids` when required.
+1. Update to a current release. The engine auto-fills zero `token_type_ids` when the model requires them.
 2. If the error persists, inspect model input names and confirm required inputs are limited to:
    - `input_ids`
    - `attention_mask`
@@ -125,9 +130,9 @@ final dbPath = MobileRag.instance.dbPath;
 // ... delete file at dbPath ...
 await MobileRag.initialize(...); // Re-initialize
 
-// Or regenerate embeddings in-place
-await MobileRag.instance.regenerateAllEmbeddings();
-await MobileRag.instance.rebuildIndex(force: true);
+// Advanced recovery: regenerate embeddings in-place.
+await MobileRag.instance.engine.regenerateAllEmbeddings();
+await MobileRag.instance.engine.rebuildIndex(force: true);
 ```
 
 ---
@@ -153,7 +158,15 @@ await MobileRag.instance.rebuildIndex();
 
 **Solutions:**
 
-1. **Limit file size** (50MB recommended):
+1. **Use file-path ingest for local files**:
+   ```dart
+   await MobileRag.instance.addDocumentFromFile(
+     file.path,
+     name: file.uri.pathSegments.last,
+   );
+   ```
+
+2. **Limit file size** (50MB recommended):
    ```dart
    final bytes = await file.readAsBytes();
    if (bytes.length > 50 * 1024 * 1024) {
@@ -161,10 +174,10 @@ await MobileRag.instance.rebuildIndex();
    }
    ```
 
-2. **Process in chunks**:
+3. **Use progress callbacks for long ingests**:
    ```dart
-   await MobileRag.instance.addDocument(
-     text,
+   await MobileRag.instance.addDocumentFromFile(
+     file.path,
      onProgress: (done, total) => print('Progress: $done/$total'),
    );
    ```

--- a/docs/test/unit_testing.md
+++ b/docs/test/unit_testing.md
@@ -59,6 +59,8 @@ void main() {
 
 ## Testing Scenarios
 
+> **Type note:** ID-bearing fields such as `chunkId`, `sourceId`, and the counters on `SourceStats` are typed as `PlatformInt64` in the generated FFI. On the supported platforms (iOS / Android / macOS) this is an `int` alias, so the `int` literals in the snippets below compile as-is. If you ever target the web, switch to `BigInt`-backed literals.
+
 ### Scenario 1: Mocking Search Results
 
 When testing UI code that displays search results, you don't need the real engine to run a query. You just need to return a predefined `RagSearchResult`.

--- a/docs/test/unit_testing.md
+++ b/docs/test/unit_testing.md
@@ -68,7 +68,9 @@ test('SearchScreen displays results correctly', () async {
   // 1. Arrange
   final mockContext = AssembledContext(
     text: "Flutter is a UI toolkit.", 
-    tokens: 5,
+    estimatedTokens: 5,
+    includedChunks: [],
+    remainingBudget: 1000,
   );
   
   // Mock the search method
@@ -90,11 +92,15 @@ test('SearchScreen displays results correctly', () async {
 
   // 2. Act
   // Calling the singleton now routes to your mock
-  final result = await MobileRag.instance.search('What is Flutter?');
+  final result = await MobileRag.instance.search(
+    'What is Flutter?',
+    tokenBudget: 1000,
+  );
 
   // 3. Assert
   expect(result.context.text, equals("Flutter is a UI toolkit."));
-  verify(() => mockRag.search(any())).called(1);
+  verify(() => mockRag.search(any(), tokenBudget: any(named: 'tokenBudget')))
+      .called(1);
 });
 ```
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
 # Mobile RAG Engine Example
 
-This example demonstrates the `mobile_rag_engine` package with the simplified `RagEngine` API.
+This example demonstrates the `mobile_rag_engine` package with the `MobileRag` facade.
 
 ## Quick Start
 
@@ -23,6 +23,7 @@ void main() async {
 
 // 2. Add documents
 await MobileRag.instance.addDocument('Your document text here');
+await MobileRag.instance.addDocumentFromFile('/path/to/document.pdf');
 await MobileRag.instance.rebuildIndex();
 
 // 3. Search
@@ -35,8 +36,8 @@ print(result.context.text);
 1. Download model files to `assets/`:
    ```bash
    cd assets
-   curl -L -o model.onnx "https://huggingface.co/Teradata/bge-m3/onnx/model_int8.onnx"
-   curl -L -o tokenizer.json "https://huggingface.co/BAAI/bge-m3/tokenizer.json"
+   curl -L -o model.onnx "https://huggingface.co/Teradata/bge-m3/resolve/main/onnx/model_int8.onnx"
+   curl -L -o tokenizer.json "https://huggingface.co/BAAI/bge-m3/resolve/main/tokenizer.json"
    ```
 
 2. Run:

--- a/example/example.md
+++ b/example/example.md
@@ -37,23 +37,17 @@ await MobileRag.instance.rebuildIndex();
 
 ## PDF & DOCX Support
 
-Can automatically extract text from PDF and DOCX files.
+Can automatically extract text from PDF and DOCX files. When you have a stable local path, prefer `addDocumentFromFile` so the native side can read and chunk the file directly.
 
 ```dart
 import 'dart:io';
 
-// Read file bytes
 final file = File('path/to/document.pdf');
-final bytes = await file.readAsBytes();
 
-// extract text (using built-in parser)
-final text = await DocumentParser.parse(bytes.toList());
-
-// Then add to RAG
-await MobileRag.instance.addDocument(
-  text, 
+await MobileRag.instance.addDocumentFromFile(
+  file.path,
   metadata: '{"source": "document.pdf"}',
-  filePath: 'document.pdf', // hints chunking strategy
+  name: 'document.pdf',
 );
 ```
 
@@ -61,10 +55,10 @@ await MobileRag.instance.addDocument(
 
 ```dart
 // Remove a source by ID
-await MobileRag.instance.engine.removeSource(sourceId);
+await MobileRag.instance.removeSource(sourceId);
 
 // Check stats
-final stats = await MobileRag.instance.engine.getStats();
+final stats = await MobileRag.instance.getStats();
 print('Total sources: ${stats.sourceCount}');
 ```
 

--- a/example/lib/screens/chunking_test_screen.dart
+++ b/example/lib/screens/chunking_test_screen.dart
@@ -359,16 +359,16 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  mobile_rag_engine: ^0.4.0
+  mobile_rag_engine: ^0.18.2
 ```
 
 ## API Reference
 
 | Function | Description |
 |----------|-------------|
-| `initDb()` | Initialize database |
-| `addDocument()` | Add document with embedding |
-| `searchSimilar()` | Vector similarity search |
+| `MobileRag.initialize()` | Initialize the local RAG engine |
+| `addDocumentFromFile()` | Add and chunk a local document |
+| `searchHybridWithContext()` | Search and assemble LLM-ready context |
 
 ## License
 

--- a/example/lib/services/rag_controller.dart
+++ b/example/lib/services/rag_controller.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:mobile_rag_engine/mobile_rag_engine.dart';
 
+const _defaultCollectionId = '__default__';
+
 class _PickedImportResult {
   final SourceAddResult addResult;
   final int? textLength;
@@ -25,18 +27,17 @@ class RagController extends ChangeNotifier {
   int? selectedSourceId;
   int topK = 5;
   final TextEditingController collectionController = TextEditingController(
-    text: SourceRagService.defaultCollectionId,
+    text: _defaultCollectionId,
   );
-  String activeCollectionId = SourceRagService.defaultCollectionId;
+  String activeCollectionId = _defaultCollectionId;
   final Set<String> knownCollectionIds = {
-    SourceRagService.defaultCollectionId,
+    _defaultCollectionId,
     'business',
     'travel',
     'personal',
   };
 
-  bool get _isDefaultCollection =>
-      activeCollectionId == SourceRagService.defaultCollectionId;
+  bool get _isDefaultCollection => activeCollectionId == _defaultCollectionId;
   CollectionRag get _activeCollection =>
       MobileRag.instance.inCollection(activeCollectionId);
 
@@ -79,7 +80,7 @@ class RagController extends ChangeNotifier {
 
   String _normalizeCollectionId(String raw) {
     final trimmed = raw.trim();
-    if (trimmed.isEmpty) return SourceRagService.defaultCollectionId;
+    if (trimmed.isEmpty) return _defaultCollectionId;
     return trimmed;
   }
 
@@ -547,7 +548,7 @@ class RagController extends ChangeNotifier {
     try {
       late final SourceStats stats;
       if (_isDefaultCollection) {
-        stats = await MobileRag.instance.engine.getStats();
+        stats = await MobileRag.instance.getStats();
         await MobileRag.instance.clearAllData();
       } else {
         stats = await _activeCollection.getStats();

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -206,7 +206,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.18.2"
+    version: "0.18.3"
   onnxruntime:
     dependency: transitive
     description:

--- a/lib/mobile_rag_engine.dart
+++ b/lib/mobile_rag_engine.dart
@@ -1,7 +1,8 @@
 /// Mobile RAG Engine
 ///
 /// A high-performance, on-device RAG (Retrieval-Augmented Generation) engine
-/// for Flutter. Run semantic search completely offline on iOS and Android.
+/// for Flutter. Run semantic search completely offline on iOS, Android, and
+/// macOS.
 ///
 /// ## Quick Start (Recommended)
 ///
@@ -30,9 +31,10 @@
 /// // Send prompt to LLM
 /// ```
 ///
-/// ## Advanced Usage (Low-Level API)
+/// ## Advanced Usage
 ///
-/// For fine-grained control, use the individual services directly:
+/// Most apps should use the [MobileRag] facade. For fine-grained workflows,
+/// use the public APIs exported by this package:
 ///
 /// ```dart
 /// await MobileRag.initialize(...) // Preferred
@@ -55,7 +57,7 @@ export 'services/text_chunker.dart';
 
 // Document parsing
 export 'services/document_parser.dart';
-// Re-export raw functions for backward compatibility
+// Re-export document parser functions for backward compatibility.
 export 'src/rust/api/document_parser.dart';
 
 // Intent parsing
@@ -88,5 +90,5 @@ export 'src/rust/api/semantic_chunker.dart'
 // Error Types
 export 'src/rust/api/error.dart' show RagError;
 
-// Note: Low-level Rust exports are hidden by default for better DX.
+// Note: other low-level Rust exports are hidden by default for better DX.
 // If you need them, import 'package:mobile_rag_engine/src/rust/api/...' directly.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_rag_engine
 description: A high-performance, on-device RAG (Retrieval-Augmented Generation) engine for Flutter. Run semantic search completely offline on iOS, Android, and macOS with HNSW vector indexing.
-version: 0.18.2
+version: 0.18.3
 homepage: https://github.com/dev07060/mobile_rag_engine
 repository: https://github.com/dev07060/mobile_rag_engine
 issue_tracker: https://github.com/dev07060/mobile_rag_engine/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mobile_rag_engine
-description: A high-performance, on-device RAG (Retrieval-Augmented Generation) engine for Flutter. Run semantic search completely offline on iOS and Android with HNSW vector indexing.
+description: A high-performance, on-device RAG (Retrieval-Augmented Generation) engine for Flutter. Run semantic search completely offline on iOS, Android, and macOS with HNSW vector indexing.
 version: 0.18.2
 homepage: https://github.com/dev07060/mobile_rag_engine
 repository: https://github.com/dev07060/mobile_rag_engine

--- a/rust_builder/README.md
+++ b/rust_builder/README.md
@@ -44,6 +44,8 @@ No additional requirements - binaries are downloaded automatically.
 | Linux | x86_64 | 🚧 Coming soon |
 | Windows | x86_64 | 🚧 Coming soon |
 
+The published package is intended for iOS, Android, and macOS consumers today. Linux and Windows source configs may exist in the repository while support is being prepared, but they are not part of the supported prebuilt-binary surface yet.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Prepare `mobile_rag_engine` `0.18.3` as a docs-only release.
- Keep README focused by removing the oversized memory benchmark note from the top of the pub.dev page.
- Align public guide/example snippets with the current `MobileRag` facade and file-path ingest APIs.

## Validation
- `flutter analyze`
- `dart pub publish --dry-run` with 0 warnings
- `dart pub publish --force`
- Verified pub.dev package page shows `mobile_rag_engine 0.18.3`
- Verified removed README phrases are no longer present on the pub.dev package page

## Notes
- `rag_engine_flutter` was not changed or published.
- The package is already published to pub.dev as `0.18.3`; this PR records the corresponding repository changes.