### PR TITLE
chore: drop redundant main-push CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
`.github/workflows/ci.yml` was firing the same 6-job matrix on both `push: branches: [main]` and `pull_request: branches: [main]`. Branch protection routes every change through a PR, so the post-merge run on `main` repeats work the PR CI already did on the equivalent merge commit. Drop the push trigger; PR CI stays the only gate.

## Coverage trade-off

The one case the post-merge run actually covered was **interleaved merges** — two PRs merged in quick succession where PR B's CI passed against a `main` tip that didn't yet contain PR A's commits. With this change, that scenario is uncovered. Given the repo's merge cadence (essentially serial, single maintainer) the ROI is tiny. If concurrent merges ever become routine, restore the `push:` block.

## Diff

```diff
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
```

## Test plan

- [ ] CI green on this PR (PR-trigger path still works).
- [ ] After merge, confirm no jobs spawn on the resulting `main` push.