### PR TITLE
feat: bound preview-path SQLite read with substr projection

### DIFF
--- a/rust_builder/rust/src/api/source_rag.rs
+++ b/rust_builder/rust/src/api/source_rag.rs
@@ -118,6 +118,20 @@ fn truncate_utf8_bytes(input: &str, max_bytes: usize) -> String {
     input[..end].to_string()
 }
 
+/// Build a `String` from a byte buffer that may end mid–UTF-8 character
+/// (typical when SQLite returns `substr(CAST(content AS BLOB), 1, N)`).
+/// The trailing partial codepoint is dropped; the result is a prefix of
+/// the original UTF-8 string.
+fn utf8_string_from_blob_prefix(mut bytes: Vec<u8>) -> String {
+    let valid_up_to = match std::str::from_utf8(&bytes) {
+        Ok(_) => bytes.len(),
+        Err(err) => err.valid_up_to(),
+    };
+    bytes.truncate(valid_up_to);
+    // SAFETY: bytes[..valid_up_to] is guaranteed valid UTF-8.
+    String::from_utf8(bytes).expect("byte prefix validated as UTF-8")
+}
+
 fn get_collection_data_generation(
     conn: &rusqlite::Connection,
     collection_id: &str,
@@ -1175,11 +1189,12 @@ impl SearchHandle {
         run_handle_hydration_test_hook();
 
         let _read_guard = QueryContentReadGuard::enter(QueryContentReadPhase::Preview);
-        let (hydrated, missing_ids) = hydrate_chunk_search_results(
+        let (hydrated, missing_ids) = hydrate_chunk_previews(
             &conn,
             &self.collection_id,
             requested_ids,
             &self.ordered_hits,
+            max_bytes,
         )?;
         self.ensure_generation_unchanged_with_conn(&conn, start_generation)?;
         if let Some(missing) = missing_ids.first() {
@@ -1193,6 +1208,10 @@ impl SearchHandle {
             .into_iter()
             .map(|chunk| {
                 let (raw_type, header_path) = decode_structured_chunk_type(&chunk.chunk_type);
+                // `hydrate_chunk_previews` already bounded `chunk.content` to
+                // at most `max_bytes` and trimmed at a UTF-8 boundary, so the
+                // call below is a no-op in the happy path. Kept as a
+                // defensive guard for future callers that bypass that path.
                 ChunkExcerptResult {
                     chunk_id: chunk.chunk_id,
                     source_id: chunk.source_id,
@@ -1552,6 +1571,92 @@ fn hydrate_chunk_search_results(
     for row in rows {
         let mut hydrated = row.map_err(|e| RagError::DatabaseError(e.to_string()))?;
         record_hydrated_content_read(hydrated.content.len() as u64);
+        if let Some(hit) = hit_by_id.get(&hydrated.chunk_id) {
+            hydrated.similarity = hit.similarity;
+        }
+        hydrated_by_id.insert(hydrated.chunk_id, hydrated);
+    }
+
+    let mut ordered = Vec::with_capacity(chunk_ids.len());
+    let mut missing_ids = Vec::new();
+    for chunk_id in chunk_ids {
+        if let Some(chunk) = hydrated_by_id.remove(&chunk_id) {
+            ordered.push(chunk);
+        } else {
+            missing_ids.push(chunk_id);
+        }
+    }
+    Ok((ordered, missing_ids))
+}
+
+/// Preview-only variant of [`hydrate_chunk_search_results`] that bounds
+/// the per-row SQLite content read to `max_bytes`. Uses
+/// `substr(CAST(c.content AS BLOB), 1, ?)` so the bound is byte-exact
+/// (TEXT substr in SQLite indexes by character, which could overshoot
+/// for multi-byte UTF-8). The trailing partial codepoint is dropped in
+/// Rust via `utf8_string_from_blob_prefix`. The `sources` LEFT JOIN is
+/// skipped because the only preview consumer (`ChunkExcerptResult`)
+/// does not surface `metadata`.
+fn hydrate_chunk_previews(
+    conn: &rusqlite::Connection,
+    collection_id: &str,
+    chunk_ids: Vec<i64>,
+    hits: &[SearchHitMeta],
+    max_bytes: u32,
+) -> Result<(Vec<ChunkSearchResult>, Vec<i64>), RagError> {
+    if chunk_ids.is_empty() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+
+    let hit_by_id = hits
+        .iter()
+        .map(|hit| (hit.chunk_id, hit))
+        .collect::<HashMap<_, _>>();
+    let id_list = chunk_ids
+        .iter()
+        .map(|id| id.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "SELECT c.id, c.source_id, c.chunk_index,
+                substr(CAST(c.content AS BLOB), 1, ?2),
+                COALESCE(c.chunk_type, 'general')
+         FROM chunks c
+         WHERE c.collection_id = ?1
+           AND c.id IN ({id_list})"
+    );
+
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    let max_bytes_i64 = max_bytes as i64;
+    let rows = stmt
+        .query_map(params![collection_id, max_bytes_i64], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i32>(2)?,
+                row.get::<_, Vec<u8>>(3)?,
+                row.get::<_, String>(4)?,
+            ))
+        })
+        .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+
+    let mut hydrated_by_id = HashMap::new();
+    for row in rows {
+        let (chunk_id, source_id, chunk_index, preview_bytes, chunk_type) =
+            row.map_err(|e| RagError::DatabaseError(e.to_string()))?;
+        record_hydrated_content_read(preview_bytes.len() as u64);
+        let content = utf8_string_from_blob_prefix(preview_bytes);
+        let mut hydrated = ChunkSearchResult {
+            chunk_id,
+            source_id,
+            chunk_index,
+            content,
+            chunk_type,
+            similarity: 0.0,
+            metadata: None,
+        };
         if let Some(hit) = hit_by_id.get(&hydrated.chunk_id) {
             hydrated.similarity = hit.similarity;
         }

--- a/test/native/query_payload_bench_test.dart
+++ b/test/native/query_payload_bench_test.dart
@@ -58,6 +58,12 @@ void main() {
       expect(result.handlePreview.nativeFullHydrateRows, 0);
       expect(result.handlePreview.nativePreviewRows, greaterThan(0));
       expect(result.handlePreview.nativeUnclassifiedRows, 0);
+      // SUBSTR projection: preview rows read strictly fewer body bytes
+      // than full hydrate rows of the same hits.
+      expect(
+        result.handlePreview.nativePreviewContentBytes,
+        lessThan(result.handleFull.nativeFullHydrateContentBytes),
+      );
 
       expect(
         result.handleContextOnly.contextBytes,


### PR DESCRIPTION
Continues the query-path body-read reduction work started in #44 and #46. With the meta-only inner from #46 already on `main`, the `hybrid_result` column is gone for handle queries; the next-largest waste was the preview path reading the entire chunk body just to trim it to `max_bytes` in Rust.

## What was happening

`SearchHandle::get_chunk_excerpts` routed through the shared `hydrate_chunk_search_results`, which always pulls `c.content` in full and joins `sources` for `metadata` neither of which the excerpt result type surfaces. The native counter from #44 made this obvious:

```
handle + preview excerpts  native_read 0.3 KB preview phase (== full hydrate)
```

At the bench fixture (chunk bodies ~70B) preview reads matched full hydrate exactly. At prod-scale chunks (~1 KB body) the preview path was reading roughly **40×** more body than it surfaced.

## What changed

New `hydrate_chunk_previews` runs:

```sql
SELECT c.id, c.source_id, c.chunk_index,
       substr(CAST(c.content AS BLOB), 1, ?max_bytes),
       COALESCE(c.chunk_type, 'general')
FROM chunks c
WHERE c.collection_id = ?1
  AND c.id IN (...)
```

- `CAST(... AS BLOB)` so `substr` indexes by **byte**, not Unicode character. (SQLite TEXT `substr` would overshoot on multi-byte scripts — e.g. Korean would still pull 3× the bound.)
- Trailing partial codepoint is dropped in Rust via a new `utf8_string_from_blob_prefix` helper.
- No `LEFT JOIN sources` — `ChunkExcerptResult` doesn't expose `metadata`.

`get_chunk_excerpts` switches to the new path. The post-fetch `truncate_utf8_bytes(&chunk.content, max_bytes)` call is left as a defensive no-op for any future caller that bypasses the SQL bound.

## Native counter movement (bench fixture, top_k=4, adjacent=1, previewMaxBytes=24)

| variant | preview phase before | preview phase after | total native before | total native after |
|---|---|---|---|---|
| handle + preview excerpts | 0.3 KB | **0.1 KB** | 0.7 KB | **0.4 KB** |

`nativePreviewContentBytes` drops ~60% on the fixture; the savings scale linearly with chunk body size, so prod-scale impact is substantially larger.

## Test plan

- [x] `cargo build --release` — clean (2 pre-existing warnings only).
- [x] `cargo test --release source_rag -- --test-threads=1` — 18/18 passed.
- [x] `flutter test test/native/query_payload_bench_test.dart` — passed with the new tightened `nativePreviewContentBytes < nativeFullHydrateContentBytes` assertion.
- [x] `flutter test test/native` — 10/10 passed.
- [x] `flutter test test/unit` — 55/55 passed.
- [x] `flutter analyze` — clean for changed files.
- [x] CI green on this branch.