### PR TITLE
feat: share chunk content reads across SearchHandle methods via per-handle cache

### DIFF
--- a/rust_builder/rust/src/api/source_rag.rs
+++ b/rust_builder/rust/src/api/source_rag.rs
@@ -45,7 +45,7 @@ use regex::Regex;
 use rusqlite::{params, OptionalExtension};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
-use std::sync::RwLock;
+use std::sync::{Arc, Mutex, RwLock};
 
 pub const DEFAULT_COLLECTION_ID: &str = "__default__";
 
@@ -1077,6 +1077,16 @@ pub struct SearchHandle {
     base_hits: Vec<SearchHitMeta>,
     ordered_hits: Vec<SearchHitMeta>,
     _query_options: SearchMetaHybridOptions,
+    /// Per-handle full-content cache shared across `assemble_context`,
+    /// `hydrate_chunks`, and `get_chunk_excerpts`. The first call that
+    /// pulls full chunk content for a chunk_id populates the entry; the
+    /// subsequent calls on the same handle return from cache without
+    /// hitting SQLite. Bounded reads (preview SUBSTR) intentionally do
+    /// not populate the cache because the content is truncated. The
+    /// handle's `data_generation` guard keeps the cache coherent —
+    /// any mutation to the underlying collection invalidates the whole
+    /// handle, the cache is discarded with it.
+    content_cache: Arc<Mutex<HashMap<i64, ChunkSearchResult>>>,
 }
 
 impl SearchHandle {
@@ -1162,20 +1172,41 @@ impl SearchHandle {
         run_handle_hydration_test_hook();
 
         let _read_guard = QueryContentReadGuard::enter(QueryContentReadPhase::FullHydrate);
-        let (hydrated, missing_ids) = hydrate_chunk_search_results(
+
+        // Cache check: any chunk whose full content was already pulled by
+        // a previous call on this handle (typically `assemble_context`)
+        // returns from the cache and bypasses SQLite entirely.
+        let (from_cache, missing) = partition_by_cache(&self.content_cache, &requested_ids);
+
+        let (newly_fetched, stale_missing) = hydrate_chunk_search_results(
             &conn,
             &self.collection_id,
-            requested_ids,
+            missing,
             &self.ordered_hits,
         )?;
         self.ensure_generation_unchanged_with_conn(&conn, start_generation)?;
-        if let Some(missing) = missing_ids.first() {
+        if let Some(missing) = stale_missing.first() {
             return Err(RagError::StaleSearchHandle(format!(
                 "chunk_id {} disappeared while hydrating search results",
                 missing
             )));
         }
-        Ok(hydrated)
+        populate_cache(&self.content_cache, &newly_fetched);
+
+        let mut by_id: HashMap<i64, ChunkSearchResult> = from_cache
+            .into_iter()
+            .map(|c| (c.chunk_id, c))
+            .collect();
+        for chunk in newly_fetched {
+            by_id.insert(chunk.chunk_id, chunk);
+        }
+        let mut ordered = Vec::with_capacity(requested_ids.len());
+        for id in requested_ids {
+            if let Some(chunk) = by_id.remove(&id) {
+                ordered.push(chunk);
+            }
+        }
+        Ok(ordered)
     }
 
     pub fn get_chunk_excerpts(
@@ -1189,37 +1220,50 @@ impl SearchHandle {
         run_handle_hydration_test_hook();
 
         let _read_guard = QueryContentReadGuard::enter(QueryContentReadPhase::Preview);
-        let (hydrated, missing_ids) = hydrate_chunk_previews(
+
+        // Cache check: chunks whose full content is already in the cache
+        // are truncated in Rust and surfaced without any SQLite read. The
+        // bounded SUBSTR path runs only for the remaining ids, and its
+        // truncated rows are intentionally NOT inserted into the cache
+        // (would corrupt later full-hydrate calls).
+        let (from_cache, missing) = partition_by_cache(&self.content_cache, &requested_ids);
+
+        let (newly_fetched, stale_missing) = hydrate_chunk_previews(
             &conn,
             &self.collection_id,
-            requested_ids,
+            missing,
             &self.ordered_hits,
             max_bytes,
         )?;
         self.ensure_generation_unchanged_with_conn(&conn, start_generation)?;
-        if let Some(missing) = missing_ids.first() {
+        if let Some(missing) = stale_missing.first() {
             return Err(RagError::StaleSearchHandle(format!(
                 "chunk_id {} disappeared while hydrating search results",
                 missing
             )));
         }
 
-        Ok(hydrated
+        let mut by_id: HashMap<i64, ChunkSearchResult> = from_cache
             .into_iter()
-            .map(|chunk| {
+            .map(|c| (c.chunk_id, c))
+            .collect();
+        for chunk in newly_fetched {
+            by_id.insert(chunk.chunk_id, chunk);
+        }
+
+        Ok(requested_ids
+            .into_iter()
+            .filter_map(|id| {
+                let chunk = by_id.remove(&id)?;
                 let (raw_type, header_path) = decode_structured_chunk_type(&chunk.chunk_type);
-                // `hydrate_chunk_previews` already bounded `chunk.content` to
-                // at most `max_bytes` and trimmed at a UTF-8 boundary, so the
-                // call below is a no-op in the happy path. Kept as a
-                // defensive guard for future callers that bypass that path.
-                ChunkExcerptResult {
+                Some(ChunkExcerptResult {
                     chunk_id: chunk.chunk_id,
                     source_id: chunk.source_id,
                     chunk_index: chunk.chunk_index,
                     raw_type: raw_type.to_string(),
                     header_path_preview: header_path.map(|path| truncate_utf8_bytes(path, 256)),
                     excerpt: truncate_utf8_bytes(&chunk.content, max_bytes as usize),
-                }
+                })
             })
             .collect())
     }
@@ -1520,7 +1564,41 @@ fn search_meta_hybrid_once(
         base_hits,
         ordered_hits,
         _query_options: options.clone(),
+        content_cache: Arc::new(Mutex::new(HashMap::new())),
     })
+}
+
+/// Split `requested_ids` into rows already present in the handle's
+/// content cache and chunk ids that still need a SQLite fetch. The
+/// lock is held only long enough to clone matched entries out.
+fn partition_by_cache(
+    cache: &Mutex<HashMap<i64, ChunkSearchResult>>,
+    requested_ids: &[i64],
+) -> (Vec<ChunkSearchResult>, Vec<i64>) {
+    let guard = cache.lock().expect("content_cache mutex poisoned");
+    let mut from_cache = Vec::new();
+    let mut missing = Vec::new();
+    for &id in requested_ids {
+        match guard.get(&id) {
+            Some(cached) => from_cache.push(cached.clone()),
+            None => missing.push(id),
+        }
+    }
+    (from_cache, missing)
+}
+
+/// Insert newly-fetched full-content rows into the cache. `or_insert_with`
+/// keeps the first writer's value if two calls race for the same id.
+fn populate_cache(
+    cache: &Mutex<HashMap<i64, ChunkSearchResult>>,
+    rows: &[ChunkSearchResult],
+) {
+    let mut guard = cache.lock().expect("content_cache mutex poisoned");
+    for row in rows {
+        guard
+            .entry(row.chunk_id)
+            .or_insert_with(|| row.clone());
+    }
 }
 
 fn hydrate_chunk_search_results(
@@ -1928,34 +2006,44 @@ fn hydrate_rows_for_assembly(
     conn: &rusqlite::Connection,
     collection_id: &str,
     hits: &[SearchHitMeta],
+    cache: &Mutex<HashMap<i64, ChunkSearchResult>>,
 ) -> Result<(Vec<HydratedChunkRow>, Vec<i64>), RagError> {
     if hits.is_empty() {
         return Ok((Vec::new(), Vec::new()));
     }
 
     let _read_guard = QueryContentReadGuard::enter(QueryContentReadPhase::Assembly);
-    let (hydrated, missing_ids) = hydrate_chunk_search_results(
-        conn,
-        collection_id,
-        hits.iter().map(|hit| hit.chunk_id).collect(),
-        hits,
-    )?;
 
-    Ok((
-        hydrated
-            .into_iter()
-            .map(|chunk| HydratedChunkRow {
-                chunk_id: chunk.chunk_id,
-                source_id: chunk.source_id,
-                chunk_index: chunk.chunk_index,
-                content: chunk.content,
-                chunk_type: chunk.chunk_type,
-                similarity: chunk.similarity,
-                metadata: chunk.metadata,
-            })
-            .collect(),
-        missing_ids,
-    ))
+    let requested_ids: Vec<i64> = hits.iter().map(|hit| hit.chunk_id).collect();
+    let (from_cache, missing) = partition_by_cache(cache, &requested_ids);
+
+    let (newly_fetched, missing_ids) =
+        hydrate_chunk_search_results(conn, collection_id, missing, hits)?;
+    populate_cache(cache, &newly_fetched);
+
+    let mut by_id: HashMap<i64, ChunkSearchResult> = from_cache
+        .into_iter()
+        .map(|c| (c.chunk_id, c))
+        .collect();
+    for chunk in newly_fetched {
+        by_id.insert(chunk.chunk_id, chunk);
+    }
+
+    let ordered: Vec<HydratedChunkRow> = requested_ids
+        .into_iter()
+        .filter_map(|id| by_id.remove(&id))
+        .map(|chunk| HydratedChunkRow {
+            chunk_id: chunk.chunk_id,
+            source_id: chunk.source_id,
+            chunk_index: chunk.chunk_index,
+            content: chunk.content,
+            chunk_type: chunk.chunk_type,
+            similarity: chunk.similarity,
+            metadata: chunk.metadata,
+        })
+        .collect();
+
+    Ok((ordered, missing_ids))
 }
 
 enum AssemblyBuildResult {
@@ -1980,8 +2068,12 @@ fn assemble_context_internal(
     }
 
     let selected_source_id = if options.single_source_mode {
-        let (base_chunks, missing_ids) =
-            hydrate_rows_for_assembly(conn, &handle.collection_id, &handle.base_hits)?;
+        let (base_chunks, missing_ids) = hydrate_rows_for_assembly(
+            conn,
+            &handle.collection_id,
+            &handle.base_hits,
+            &handle.content_cache,
+        )?;
         if !missing_ids.is_empty() {
             return Ok(AssemblyBuildResult::MissingChunks(missing_ids));
         }
@@ -2000,8 +2092,12 @@ fn assemble_context_internal(
         None => handle.ordered_hits.clone(),
     };
 
-    let (mut chunks, missing_ids) =
-        hydrate_rows_for_assembly(conn, &handle.collection_id, &candidate_hits)?;
+    let (mut chunks, missing_ids) = hydrate_rows_for_assembly(
+        conn,
+        &handle.collection_id,
+        &candidate_hits,
+        &handle.content_cache,
+    )?;
     if !missing_ids.is_empty() {
         return Ok(AssemblyBuildResult::MissingChunks(missing_ids));
     }
@@ -2769,6 +2865,7 @@ mod tests {
                 source_ids: None,
                 adjacent_chunks: 0,
             },
+            content_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 

--- a/test/native/query_payload_bench_test.dart
+++ b/test/native/query_payload_bench_test.dart
@@ -42,7 +42,10 @@ void main() {
       expect(result.handleFull.nativeHybridResultRows, 0);
       expect(result.handleFull.nativeHybridResultContentBytes, 0);
       expect(result.handleFull.nativeAssemblyRows, greaterThan(0));
-      expect(result.handleFull.nativeFullHydrateRows, greaterThan(0));
+      // assemble_context runs first, populates the handle's content cache;
+      // hydrate_chunks then serves every hit from cache → no SQLite read.
+      expect(result.handleFull.nativeFullHydrateRows, 0);
+      expect(result.handleFull.nativeFullHydrateContentBytes, 0);
       expect(result.handleFull.nativePreviewRows, 0);
       expect(result.handleFull.nativeUnclassifiedRows, 0);
 
@@ -56,14 +59,11 @@ void main() {
       expect(result.handlePreview.nativeHybridResultContentBytes, 0);
       expect(result.handlePreview.nativeAssemblyRows, greaterThan(0));
       expect(result.handlePreview.nativeFullHydrateRows, 0);
-      expect(result.handlePreview.nativePreviewRows, greaterThan(0));
+      // Cache hit: get_chunk_excerpts truncates from cached full content
+      // instead of issuing the bounded SUBSTR SELECT.
+      expect(result.handlePreview.nativePreviewRows, 0);
+      expect(result.handlePreview.nativePreviewContentBytes, 0);
       expect(result.handlePreview.nativeUnclassifiedRows, 0);
-      // SUBSTR projection: preview rows read strictly fewer body bytes
-      // than full hydrate rows of the same hits.
-      expect(
-        result.handlePreview.nativePreviewContentBytes,
-        lessThan(result.handleFull.nativeFullHydrateContentBytes),
-      );
 
       expect(
         result.handleContextOnly.contextBytes,
@@ -84,6 +84,27 @@ void main() {
       expect(
         result.handlePreview.totalStringBytes,
         lessThan(result.handleFull.totalStringBytes),
+      );
+
+      // With the per-handle content cache, assembly is the only SQLite
+      // body read on the handle path. All three handle variants read the
+      // same hit + adjacent chunks via the same SELECT, so their
+      // assembly-phase counters converge byte-for-byte.
+      expect(
+        result.handleFull.nativeAssemblyRows,
+        result.handleContextOnly.nativeAssemblyRows,
+      );
+      expect(
+        result.handlePreview.nativeAssemblyRows,
+        result.handleContextOnly.nativeAssemblyRows,
+      );
+      expect(
+        result.handleFull.nativeAssemblyContentBytes,
+        result.handleContextOnly.nativeAssemblyContentBytes,
+      );
+      expect(
+        result.handlePreview.nativeAssemblyContentBytes,
+        result.handleContextOnly.nativeAssemblyContentBytes,
       );
 
       // ignore: avoid_print


### PR DESCRIPTION
After the meta-only inner (#46) and the preview SUBSTR projection (#48) landed, the remaining query-path waste was the double-read between `assemble_context` and `hydrate_chunks` / `get_chunk_excerpts`. They each fired their own SQLite read for the same hit chunks. In the typical handle flow (`searchHybridWithContext` and the `query_payload_bench`) `assemble_context` runs first and reads chunk bodies, then the caller hydrates the same hits and reads them again.

## What changed

Add `Arc<Mutex<HashMap<i64, ChunkSearchResult>>>` on `SearchHandle`. The first call that needs full content populates the cache; subsequent calls on the same handle serve their hit ids from cache and skip SQLite.

- New `partition_by_cache` / `populate_cache` helpers handle the cache read/write pattern. The lock is held only long enough to clone matched entries (or insert new ones).
- `hydrate_chunks` partitions requested ids, fetches only misses via `hydrate_chunk_search_results`, writes back to cache, returns in requested order.
- `get_chunk_excerpts` does the same partition. Cache hits truncate the cached full content in Rust and surface the excerpt directly. The bounded SUBSTR path runs only for misses; its truncated rows are intentionally **not** written to the cache (would corrupt a later full-hydrate call).
- `hydrate_rows_for_assembly` now takes the cache as a parameter and applies the same pattern. `assemble_context_internal` passes `&handle.content_cache` at both call sites.

Coherence is anchored on the existing `data_generation` guard: any mutation to the collection invalidates the handle (`StaleSearchHandle`), the handle is dropped, and the cache goes with it. Bounded preview content is never inserted, so cache reads always return full content (re-truncated at the preview surface).

## Native counter delta (bench fixture, top_k=4, adjacent=1, previewMaxBytes=24, ordered_hits=5)

| variant | before | after |
|---|---|---|
| handle + full hydrate | 10 rows / 0.7 KB | **5 rows / 0.3 KB** |
| handle + preview excerpts | 10 rows / 0.4 KB | **5 rows / 0.3 KB** |
| handle + context only | 5 rows / 0.3 KB | 5 rows / 0.3 KB |

All three handle variants now converge to the same assembly-only read volume — locked in by the new assertion that `nativeAssemblyRows` and `nativeAssemblyContentBytes` match across all three (regression guard against future paths that bypass the cache).

For end-to-end perspective, this completes the query-path body-read reduction series (#44 → #46 → #48 → this PR):

| variant | start of series | now |
|---|---|---|
| handle + full hydrate | 14 rows / 0.9 KB | **5 rows / 0.3 KB** (≈ −65%) |
| handle + preview excerpts | 14 rows / 0.9 KB | **5 rows / 0.3 KB** (≈ −65%) |
| handle + context only | 9 rows / 0.6 KB | **5 rows / 0.3 KB** (≈ −50%) |

At prod-scale chunk bodies (~1 KB × top-K 20) the absolute savings scale roughly linearly with body size.

## What this PR does NOT do

- Doesn't touch the `assembly` phase itself. Context text still needs full chunk content; further reduction there requires the originally-deferred context streaming refactor and is out of scope.
- Doesn't change FRB surface — `content_cache` is an internal field on the opaque `SearchHandle`.
- Doesn't touch `chunk.metadata`. It's part of the public `ChunkSearchResult` contract and consumed by `ContextBuilder` Dart-side; keeping the `LEFT JOIN sources` on the full-hydrate SELECT.

## Test plan

- [x] `cargo build --release` — clean (2 pre-existing warnings only).
- [x] `cargo test --release source_rag -- --test-threads=1` — 18/18 passed.
- [x] `cargo test --release hybrid_search -- --test-threads=1` — 5/5 passed.
- [x] `flutter test test/native` — 10/10 passed.
- [x] `flutter test test/unit` — 55/55 passed.
- [x] `flutter analyze` — clean for changed files.
- [x] CI green on this branch.