### PR TITLE
elide scoped exact-scan content reads

### DIFF
--- a/docs/features/hybrid_scoped_exact_scan_content_elision.html
+++ b/docs/features/hybrid_scoped_exact_scan_content_elision.html
@@ -1,0 +1,435 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Hybrid Scoped Exact-Scan — Content Projection Elision</title>
+<style>
+  :root {
+    --bg: #fafafa;
+    --fg: #1a1a1a;
+    --muted: #555;
+    --line: #d0d0d0;
+    --accent: #1f6feb;
+    --good: #1a7f37;
+    --bad: #c43a3a;
+    --code-bg: #f4f4f4;
+  }
+  html, body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font: 15px/1.55 -apple-system, "SF Pro Text", "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+  main {
+    max-width: 880px;
+    margin: 2.5rem auto 4rem;
+    padding: 0 1.25rem;
+  }
+  h1 { font-size: 1.7rem; margin: 0 0 .5rem; }
+  h2 {
+    font-size: 1.2rem;
+    margin: 2rem 0 .6rem;
+    padding-bottom: .25rem;
+    border-bottom: 1px solid var(--line);
+  }
+  h3 { font-size: 1rem; margin: 1.5rem 0 .4rem; }
+  .meta {
+    color: var(--muted);
+    font-size: .85rem;
+    margin-bottom: 1.25rem;
+  }
+  .meta code { background: none; padding: 0; }
+  .summary {
+    border-left: 3px solid var(--accent);
+    background: #fff;
+    padding: .85rem 1rem;
+    margin: 1rem 0 1.5rem;
+  }
+  .summary p { margin: .25rem 0; }
+  code, pre {
+    font-family: "SF Mono", Menlo, Consolas, monospace;
+    font-size: .85em;
+  }
+  code { background: var(--code-bg); padding: .1em .35em; border-radius: 3px; }
+  pre {
+    background: var(--code-bg);
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    padding: .75rem .9rem;
+    overflow-x: auto;
+    line-height: 1.45;
+  }
+  pre code { background: none; padding: 0; }
+  table {
+    border-collapse: collapse;
+    margin: .5rem 0 1rem;
+    width: 100%;
+    font-size: .9rem;
+  }
+  th, td {
+    border: 1px solid var(--line);
+    padding: .35rem .6rem;
+    text-align: left;
+    vertical-align: top;
+  }
+  th { background: #f0f0f0; }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .good { color: var(--good); font-weight: 600; }
+  .bad  { color: var(--bad);  font-weight: 600; }
+  .pill {
+    display: inline-block;
+    padding: .05rem .45rem;
+    border-radius: 9px;
+    background: #eef;
+    color: #225;
+    font-size: .8em;
+  }
+  ul { padding-left: 1.4rem; }
+  li { margin-bottom: .25rem; }
+  .legend {
+    color: var(--muted);
+    font-size: .85rem;
+    margin-top: -.5rem;
+  }
+</style>
+</head>
+<body>
+<main>
+
+<h1>Hybrid Scoped Exact-Scan — Content Projection Elision</h1>
+<div class="meta">
+  P0 query-path optimization &nbsp;·&nbsp;
+  Branch: <code>enhancement/scoped-exact-scan-elision</code>
+  (rebased onto <code>origin/main</code> @ <code>abf6b7e</code>, which includes
+  PR #49 handle-content-cache) &nbsp;·&nbsp;
+  Owner: bhoh@polarpulse.ai &nbsp;·&nbsp;
+  Date: 2026-05-17
+</div>
+
+<div class="summary">
+  <p><strong>What changed.</strong> The scoped exact-scan branch of <code>hybrid_search</code>
+  (the path triggered by <code>source_ids</code> / <code>metadata_like</code> filters) used to
+  pull <code>c.content</code> for every scoped chunk unconditionally. We now elide that column
+  from the <code>SELECT</code> when the BM25 leg cannot contribute to the final RRF score.</p>
+  <p><strong>Net effect.</strong> When callers pass <code>bm25_weight = 0</code> (or the query
+  produces no BM25 tokens), the scoped exact-scan reads <strong class="good">zero</strong> chunk
+  bytes regardless of scope size. With <code>bm25_weight &gt; 0</code> the behavior is unchanged.</p>
+  <p><strong>Why P0.</strong> The previous behavior scaled linearly with the scoped set —
+  500 chunks × ~256 B ≈ 125 KB of SQLite content read per query, even when the bytes were
+  never tokenized. That growth is independent of <code>top_k</code>, so it dominates large
+  scoped filters.</p>
+</div>
+
+<h2>Background</h2>
+
+<p>The scoped exact-scan branch is the fallback hybrid search runs when a query carries
+<code>source_ids</code> or <code>metadata_like</code> filters. Instead of querying global vector /
+BM25 indexes and post-filtering, it walks every chunk under the scope and re-scores both
+legs in-process. This trades index latency for recall on small scoped subsets.</p>
+
+<p>The legacy <code>SELECT</code> read four columns per row:
+<code>c.id</code>, <code>c.embedding</code>, <code>c.embedding_i8</code>, <code>c.content</code>.
+Only the first three are needed for vector scoring; <code>c.content</code> exists solely so the
+per-row BM25 collector can tokenize the chunk body.</p>
+
+<p>The BM25 leg only contributes to the final RRF score when both:</p>
+<ul>
+  <li><code>config.bm25_weight &gt; 0.0</code> — otherwise it is multiplied by zero, and</li>
+  <li><code>tokenize_for_bm25(query_text)</code> returns at least one term — otherwise no chunk
+  can match.</li>
+</ul>
+
+<p>Whenever one of those is false, every byte read from <code>c.content</code> is pure I/O waste.</p>
+
+<h2>Instrumentation (landed first)</h2>
+
+<p>Before changing behavior we landed a counter in <code>query_metrics</code> so the cost was
+measurable end-to-end:</p>
+
+<pre><code>// rust_builder/rust/src/api/query_metrics.rs
+static SCOPED_EXACT_SCAN_CONTENT: AtomicCounter = AtomicCounter::new();
+
+pub(crate) fn record_scoped_exact_scan_content_read(content_bytes: u64) {
+    SCOPED_EXACT_SCAN_CONTENT.record(content_bytes);
+}
+
+pub struct QueryContentReadStats {
+    // … existing fields …
+    pub scoped_exact_scan_rows: u64,
+    pub scoped_exact_scan_content_bytes: u64,
+}</code></pre>
+
+<p>The counter is intentionally <em>not</em> included in <code>rows_total()</code> /
+<code>content_bytes_total()</code> — those describe materialized result reads, while this one
+measures <em>backend scan</em> reads. A scoped chunk that survives RRF is read once during the
+scan and (if needed) once again during hydration; conflating them would double-count.</p>
+
+<h2>Change</h2>
+
+<h3>SELECT projection becomes conditional</h3>
+
+<pre><code>// rust_builder/rust/src/api/hybrid_search.rs (scoped branch)
+let query_tokens = tokenize_for_bm25(&query_text);
+let query_token_set: HashSet&lt;String&gt; = query_tokens.iter().cloned().collect();
+// `!= 0.0` (not `&gt; 0.0`) — preserves prior behavior for any non-zero weight,
+// including negative values that callers might pass.
+let need_bm25 = config.bm25_weight != 0.0 &amp;&amp; !query_token_set.is_empty();
+let content_projection = if need_bm25 { "c.content" } else { "NULL AS content" };
+
+let query_with_i8 = format!(
+    "SELECT c.id, c.embedding, {}, {}
+         FROM chunks c
+         LEFT JOIN sources s ON c.source_id = s.id
+         WHERE {}",
+    "c.embedding_i8",
+    content_projection,
+    exact_conditions.join(" AND ")
+);</code></pre>
+
+<p>Notes:</p>
+<ul>
+  <li>The token set is computed once, before the SQL prepare, and the same predicate
+  guards both the projection and the post-scan BM25 scoring block.</li>
+  <li>The fallback prepare (the <code>NULL AS embedding_i8</code> path used on schemas without
+  the i8 column) goes through the same projection.</li>
+  <li>The gate uses <code>!= 0.0</code> rather than <code>&gt; 0.0</code> so any non-zero
+  weight — including negative weights some callers use as a penalty — keeps the prior
+  behavior of reading content and computing BM25. We only elide when the BM25
+  contribution to RRF is provably zero.</li>
+</ul>
+
+<h3>Row reader treats content as nullable</h3>
+
+<pre><code>let chunk_iter = stmt.query_map([], |row| {
+    Ok((
+        row.get::&lt;_, i64&gt;(0)?,
+        row.get::&lt;_, Vec&lt;u8&gt;&gt;(1)?,
+        row.get::&lt;_, Option&lt;Vec&lt;u8&gt;&gt;&gt;(2)?,
+        row.get::&lt;_, Option&lt;String&gt;&gt;(3)?,   // was: String
+    ))
+})?;
+
+for row in chunk_iter {
+    if let Ok((id, embedding_blob, embedding_i8_blob, content)) = row {
+        if let Some(ref content_str) = content {
+            record_scoped_exact_scan_content_read(content_str.len() as u64);
+        }
+        // … vector scoring (unchanged) …
+
+        if need_bm25 {
+            if let Some(content_str) = content {
+                // … existing BM25 token / df / tf collection …
+            }
+        }
+    }
+}</code></pre>
+
+<p>The counter only fires when content was actually pulled. The post-scan scoring block also
+flips its guard from <code>!query_tokens.is_empty()</code> to <code>need_bm25</code>, so the two
+gates stay in lockstep.</p>
+
+<h2>Measured impact</h2>
+
+<p>Captured by <code>BenchmarkService.benchmarkScopedExactScan</code>. Each variant runs
+<code>searchMetaHybrid</code> against a single scoped source seeded with N × 256 B chunks,
+with a small distractor source so the scope filter has something to exclude.</p>
+
+<h3>Scoped exact-scan content read (per query)</h3>
+<table>
+  <thead>
+    <tr>
+      <th>Scope size</th><th>bm25_weight</th>
+      <th class="num">Before — rows</th><th class="num">Before — bytes</th>
+      <th class="num">After — rows</th><th class="num">After — bytes</th>
+      <th class="num">Reduction</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>50 chunks</td><td>0.0</td>
+      <td class="num">50</td><td class="num">12.5 KB</td>
+      <td class="num good">0</td><td class="num good">0 KB</td>
+      <td class="num good">100%</td>
+    </tr>
+    <tr>
+      <td>50 chunks</td><td>0.5</td>
+      <td class="num">50</td><td class="num">12.5 KB</td>
+      <td class="num">50</td><td class="num">12.5 KB</td>
+      <td class="num">0% (intended)</td>
+    </tr>
+    <tr>
+      <td>500 chunks</td><td>0.0</td>
+      <td class="num">500</td><td class="num">125 KB</td>
+      <td class="num good">0</td><td class="num good">0 KB</td>
+      <td class="num good">100%</td>
+    </tr>
+    <tr>
+      <td>500 chunks</td><td>0.5</td>
+      <td class="num">500</td><td class="num">125 KB</td>
+      <td class="num">500</td><td class="num">125 KB</td>
+      <td class="num">0% (intended)</td>
+    </tr>
+  </tbody>
+</table>
+<p class="legend">Bytes are SQLite <code>c.content</code> reads observed via the
+<code>scoped_exact_scan_*</code> counter. Source: <code>test/native/scoped_exact_scan_bench_test.dart</code>,
+release-profile Rust build on macOS / arm64.</p>
+
+<h3>Adjacent baseline (post-PR #49 handle-content-cache)</h3>
+
+<p>Re-running <code>query_payload_bench_test</code> on the rebased base confirms the
+<code>SearchHandle</code> path benefits from PR #49's per-handle content cache: all three
+hydration variants now read the chunk body exactly once during assembly and reuse it,
+which is the surface this change builds on. Numbers are stable across runs.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Variant</th>
+      <th class="num">native rows</th>
+      <th class="num">native bytes</th>
+      <th>phase split</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>legacy searchHybrid</code></td>
+      <td class="num">4</td><td class="num">0.3 KB</td>
+      <td><code>hybrid=0.3 KB</code> (materialized result)</td>
+    </tr>
+    <tr>
+      <td><code>handle + full hydrate</code></td>
+      <td class="num">5</td><td class="num">0.3 KB</td>
+      <td><code>assembly=0.3 KB</code>, full/preview/unclassified all 0</td>
+    </tr>
+    <tr>
+      <td><code>handle + preview excerpts</code></td>
+      <td class="num">5</td><td class="num">0.3 KB</td>
+      <td><code>assembly=0.3 KB</code>, full/preview/unclassified all 0</td>
+    </tr>
+    <tr>
+      <td><code>handle + context only</code></td>
+      <td class="num">5</td><td class="num">0.3 KB</td>
+      <td><code>assembly=0.3 KB</code>, full/preview/unclassified all 0</td>
+    </tr>
+  </tbody>
+</table>
+<p class="legend">All four variants report <code>scoped_exact_scan rows=0 bytes=0 KB</code>
+because the benchmark uses a <code>collection_id</code>-only filter, which does not
+trigger the scoped exact-scan path. Captured from
+<code>flutter test test/native/query_payload_bench_test.dart</code>, release build,
+2026-05-17 on macOS / arm64.</p>
+
+<h3>Behavior we did <em>not</em> change</h3>
+<ul>
+  <li><code>bm25_weight != 0</code> path — identical reads, identical ranking. Verified by
+  <code>test_scoped_exact_scan_skips_content_when_bm25_disabled</code> (top-K is stable).
+  Includes negative weights (treated as a BM25 penalty by RRF); they keep the previous
+  body-reading behavior intact.</li>
+  <li>Non-scoped queries — unchanged, the post-filter path doesn't touch content for
+  scoring.</li>
+  <li>Hydration counters (<code>full_hydrate_*</code>, <code>preview_*</code>, <code>assembly_*</code>) —
+  unchanged; those still record materialized result reads in <code>SearchHandle</code>.</li>
+  <li>The <code>collection_id</code>-only filter path still uses post-filter against the
+  global indexes; it does not enter the scoped exact-scan branch.</li>
+</ul>
+
+<h2>Test coverage</h2>
+
+<ul>
+  <li><strong>Cargo</strong> — <code>api::hybrid_search::tests::test_scoped_exact_scan_skips_content_when_bm25_disabled</code>:
+  asserts the counter is exactly zero with <code>bm25_weight = 0</code> and ≥ (sum of chunk
+  body lengths) with <code>bm25_weight &gt; 0</code>; also asserts vector-only top rank is
+  preserved.</li>
+  <li><strong>Cargo</strong> — pre-existing <code>test_hybrid_source_filter_exact_scan_keeps_scoped_bm25</code>
+  still passes (BM25 path untouched).</li>
+  <li><strong>Cargo</strong> — pre-existing <code>test_collection_filter_only_uses_post_filter_not_exact_scan</code>
+  still passes (collection-only filter does not trigger scoped scan).</li>
+  <li><strong>Dart</strong> — <code>test/native/scoped_exact_scan_bench_test.dart</code> drives
+  <code>searchMetaHybrid</code> across {50, 500} scoped chunks × {0.0, 0.5} BM25 weights and
+  asserts the counter is zero on the elided path and scales linearly on the BM25 path.</li>
+  <li><strong>Dart</strong> — pre-existing <code>test/native/query_payload_bench_test.dart</code>
+  unchanged in semantics; renderer now includes a <code>scoped_exact_scan</code> row that
+  reads 0 / 0 KB for non-scoped variants.</li>
+</ul>
+
+<h2>Files touched</h2>
+
+<table>
+  <thead><tr><th>File</th><th>Change</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>rust_builder/rust/src/api/query_metrics.rs</code></td>
+      <td>Add <code>SCOPED_EXACT_SCAN_CONTENT</code> counter,
+      <code>record_scoped_exact_scan_content_read</code>, two struct fields, snapshot/reset
+      wiring.</td>
+    </tr>
+    <tr>
+      <td><code>rust_builder/rust/src/api/hybrid_search.rs</code></td>
+      <td>Hoist tokenization, compute <code>need_bm25</code>, switch SELECT projection,
+      tolerate <code>NULL</code> content, gate counter + BM25 collection + post-scan scoring on
+      <code>need_bm25</code>. New cargo test.</td>
+    </tr>
+    <tr>
+      <td><code>lib/src/rust/api/query_metrics.dart</code></td>
+      <td>FRB-regenerated bindings — adds <code>scopedExactScanRows</code> /
+      <code>scopedExactScanContentBytes</code>.</td>
+    </tr>
+    <tr>
+      <td><code>lib/services/benchmark_service.dart</code></td>
+      <td>Extend <code>QueryPayloadVariantStats</code>, add
+      <code>benchmarkScopedExactScan</code> + <code>ScopedExactScanBenchResult</code>.</td>
+    </tr>
+    <tr>
+      <td><code>test/native/scoped_exact_scan_bench_test.dart</code></td>
+      <td>New end-to-end coverage for the elided / non-elided matrix.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>Compatibility</h2>
+
+<ul>
+  <li>No public API surface changes. <code>SearchFilter</code>, <code>RrfConfig</code>,
+  <code>SearchMetaHybridOptions</code>, and the Dart-side wrappers are byte-for-byte
+  identical for callers.</li>
+  <li>FRB struct shape gained two trailing fields. The native dylib and Dart bindings must
+  be rebuilt together — older clients pinned to the previous bindings will fail to decode
+  the stats struct.</li>
+  <li>Behavior of <code>search_hybrid</code> / <code>search_hybrid_simple</code> /
+  <code>search_hybrid_weighted</code> is unchanged for every input that previously produced a
+  ranked result; only the SQL projection and a counter are different.</li>
+</ul>
+
+<h2>Follow-ups (deferred)</h2>
+
+<ul>
+  <li>When <code>bm25_weight != 0</code> but <code>top_k</code> is tiny relative to scope (say
+  500 → 4), we still tokenize 500 bodies to score 4 winners. Possible next P1: precomputed
+  per-chunk BM25 term stats, or a scoped BM25 index keyed by source.</li>
+  <li>Tokenization itself still allocates per-token <code>String</code>s — orthogonal to this
+  change; tracked separately as the copy-elision candidate the user flagged in the same
+  triage.</li>
+  <li>The benchmark fixture uses synthetic 256 B chunks; real-world chunk bodies are
+  typically 1–4 KB, so the absolute scan-bytes savings on a 500-chunk scope scale to
+  0.5–2 MB per query, not 125 KB.</li>
+</ul>
+
+<h2>How to reproduce the numbers</h2>
+
+<pre><code># From repo root, on the rebased branch (enhancement/scoped-exact-scan-elision):
+flutter_rust_bridge_codegen generate
+cargo build --manifest-path rust_builder/rust/Cargo.toml --release
+cargo test --manifest-path rust_builder/rust/Cargo.toml --lib -- --test-threads=1
+flutter test test/native/scoped_exact_scan_bench_test.dart --reporter expanded
+flutter test test/native/query_payload_bench_test.dart    --reporter expanded</code></pre>
+
+<p class="legend">Each <code>flutter test</code> run prints the per-variant summary to
+stdout via <code>renderSummary()</code>; the table values in this doc are the
+release-build, single-iteration numbers (no warmup loop, since the bench is a
+correctness test, not a latency benchmark — wall-clock numbers are quoted only to
+show the elision path is not slower).</p>
+
+</main>
+</body>
+</html>

--- a/lib/services/benchmark_service.dart
+++ b/lib/services/benchmark_service.dart
@@ -255,6 +255,63 @@ class BenchmarkService {
     );
   }
 
+  static QueryPayloadVariantStats _variantStatsFromNative({
+    required String label,
+    required double elapsedMs,
+    required int hitCount,
+    int metaBytes = 0,
+    int contextBytes = 0,
+    int fullChunkBytes = 0,
+    int previewBytes = 0,
+    query_metrics.QueryContentReadStats? nativeReadStats,
+  }) {
+    return QueryPayloadVariantStats(
+      label: label,
+      elapsedMs: elapsedMs,
+      hitCount: hitCount,
+      metaBytes: metaBytes,
+      contextBytes: contextBytes,
+      fullChunkBytes: fullChunkBytes,
+      previewBytes: previewBytes,
+      nativeHybridResultRows: _bigIntToInt(
+        nativeReadStats?.hybridResultRows ?? BigInt.zero,
+      ),
+      nativeHybridResultContentBytes: _bigIntToInt(
+        nativeReadStats?.hybridResultContentBytes ?? BigInt.zero,
+      ),
+      nativeFullHydrateRows: _bigIntToInt(
+        nativeReadStats?.fullHydrateRows ?? BigInt.zero,
+      ),
+      nativeFullHydrateContentBytes: _bigIntToInt(
+        nativeReadStats?.fullHydrateContentBytes ?? BigInt.zero,
+      ),
+      nativePreviewRows: _bigIntToInt(
+        nativeReadStats?.previewRows ?? BigInt.zero,
+      ),
+      nativePreviewContentBytes: _bigIntToInt(
+        nativeReadStats?.previewContentBytes ?? BigInt.zero,
+      ),
+      nativeAssemblyRows: _bigIntToInt(
+        nativeReadStats?.assemblyRows ?? BigInt.zero,
+      ),
+      nativeAssemblyContentBytes: _bigIntToInt(
+        nativeReadStats?.assemblyContentBytes ?? BigInt.zero,
+      ),
+      nativeUnclassifiedRows: _bigIntToInt(
+        nativeReadStats?.unclassifiedRows ?? BigInt.zero,
+      ),
+      nativeUnclassifiedContentBytes: _bigIntToInt(
+        nativeReadStats?.unclassifiedContentBytes ?? BigInt.zero,
+      ),
+      nativeScopedExactScanRows: _bigIntToInt(
+        nativeReadStats?.scopedExactScanRows ?? BigInt.zero,
+      ),
+      nativeScopedExactScanContentBytes: _bigIntToInt(
+        nativeReadStats?.scopedExactScanContentBytes ?? BigInt.zero,
+      ),
+    );
+  }
+
   /// Measure current query/search payload shape without changing runtime
   /// behavior.
   ///
@@ -393,7 +450,7 @@ class BenchmarkService {
       int previewBytes = 0,
       query_metrics.QueryContentReadStats? nativeReadStats,
     }) {
-      return QueryPayloadVariantStats(
+      return _variantStatsFromNative(
         label: label,
         elapsedMs: elapsedMs,
         hitCount: hitCount,
@@ -401,36 +458,7 @@ class BenchmarkService {
         contextBytes: contextBytes,
         fullChunkBytes: fullChunkBytes,
         previewBytes: previewBytes,
-        nativeHybridResultRows: _bigIntToInt(
-          nativeReadStats?.hybridResultRows ?? BigInt.zero,
-        ),
-        nativeHybridResultContentBytes: _bigIntToInt(
-          nativeReadStats?.hybridResultContentBytes ?? BigInt.zero,
-        ),
-        nativeFullHydrateRows: _bigIntToInt(
-          nativeReadStats?.fullHydrateRows ?? BigInt.zero,
-        ),
-        nativeFullHydrateContentBytes: _bigIntToInt(
-          nativeReadStats?.fullHydrateContentBytes ?? BigInt.zero,
-        ),
-        nativePreviewRows: _bigIntToInt(
-          nativeReadStats?.previewRows ?? BigInt.zero,
-        ),
-        nativePreviewContentBytes: _bigIntToInt(
-          nativeReadStats?.previewContentBytes ?? BigInt.zero,
-        ),
-        nativeAssemblyRows: _bigIntToInt(
-          nativeReadStats?.assemblyRows ?? BigInt.zero,
-        ),
-        nativeAssemblyContentBytes: _bigIntToInt(
-          nativeReadStats?.assemblyContentBytes ?? BigInt.zero,
-        ),
-        nativeUnclassifiedRows: _bigIntToInt(
-          nativeReadStats?.unclassifiedRows ?? BigInt.zero,
-        ),
-        nativeUnclassifiedContentBytes: _bigIntToInt(
-          nativeReadStats?.unclassifiedContentBytes ?? BigInt.zero,
-        ),
+        nativeReadStats: nativeReadStats,
       );
     }
 
@@ -570,6 +598,198 @@ class BenchmarkService {
         handleContextOnly: await runHandleVariant(
           _QueryPayloadHydration.contextOnly,
         ),
+      );
+    } finally {
+      query_metrics.resetQueryContentReadStats();
+      await closeDbPool();
+      if (await benchFile.exists()) {
+        await benchFile.delete();
+      }
+      if (await tokenizerFile.exists()) {
+        await tokenizerFile.delete();
+      }
+      if (restoreDbPath != null) {
+        await initDbPool(dbPath: restoreDbPath, maxSize: 4);
+      }
+    }
+  }
+
+  /// Measure the scoped exact-scan branch of `searchMetaHybrid`.
+  ///
+  /// Seeds one scoped source with [scopedChunkCount] chunks (each ~256 ASCII
+  /// bytes) plus a distractor source so the post-filter path has work to do,
+  /// then runs `searchMetaHybrid` with `sourceIds=[scopedSourceId]` across the
+  /// supplied [bm25Weights]. Each variant captures `query_metrics`
+  /// `scoped_exact_scan_*` counters before disposing the handle, so the caller
+  /// can compare scan bytes against the BM25 toggle and scope size.
+  ///
+  /// Intentionally meta-only — no hydration, no assemble — so the recorded
+  /// scoped-scan bytes are not blurred with `full_hydrate_*` materialization.
+  static Future<ScopedExactScanBenchResult> benchmarkScopedExactScan({
+    int scopedChunkCount = 50,
+    int distractorChunkCount = 10,
+    int topK = 4,
+    int chunkContentChars = 256,
+    List<double> bm25Weights = const [0.0, 0.5],
+    String? restoreDbPath,
+    String? dbPathOverride,
+  }) async {
+    const collectionId = 'bench-scoped-exact-scan';
+    const queryText = 'install checksum smoke';
+    final queryEmbedding = Float32List.fromList([1.0, 0.0, 0.0, 0.0]);
+
+    final benchDbPath =
+        dbPathOverride ??
+        "${(await getApplicationDocumentsDirectory()).path}/scoped_exact_scan_bench.sqlite";
+    final benchFile = File(benchDbPath);
+    if (await benchFile.exists()) {
+      await benchFile.delete();
+    }
+    final tokenizerFile = File('$benchDbPath.tokenizer.json');
+    if (await tokenizerFile.exists()) {
+      await tokenizerFile.delete();
+    }
+
+    await initDbPool(dbPath: benchDbPath, maxSize: 4);
+    await initDb();
+    await source_rag.initSourceDb();
+    await tokenizerFile.writeAsString(
+      '{"version":"1.0","truncation":null,"padding":null,'
+      '"added_tokens":[],"normalizer":null,'
+      '"pre_tokenizer":{"type":"Whitespace"},"post_processor":null,'
+      '"decoder":null,"model":{"type":"WordLevel",'
+      '"vocab":{"[UNK]":0,"install":1,"checksum":2,"smoke":3,"setup":4},'
+      '"unk_token":"[UNK]"}}',
+      flush: true,
+    );
+    await initTokenizer(tokenizerPath: tokenizerFile.path);
+
+    String makeChunkContent(int seed) {
+      const words = [
+        'install',
+        'checksum',
+        'smoke',
+        'setup',
+        'verify',
+        'archive',
+        'manifest',
+        'release',
+        'config',
+        'package',
+      ];
+      final buffer = StringBuffer();
+      var i = seed;
+      while (buffer.length < chunkContentChars) {
+        if (buffer.isNotEmpty) buffer.write(' ');
+        buffer.write(words[i % words.length]);
+        i++;
+      }
+      return buffer.toString().substring(0, chunkContentChars);
+    }
+
+    Future<int> seedSource({
+      required String name,
+      required int chunkCount,
+      required int seedBase,
+    }) async {
+      final source = await source_rag.addSourceInCollection(
+        collectionId: collectionId,
+        content: 'bench source $name',
+        metadata: '{"source":"$name"}',
+        name: name,
+      );
+      await source_rag.updateSourceStatus(
+        sourceId: source.sourceId,
+        status: 'completed',
+      );
+      var cursor = 0;
+      final chunkData = <source_rag.ChunkData>[];
+      for (var i = 0; i < chunkCount; i++) {
+        final content = makeChunkContent(seedBase + i);
+        chunkData.add(
+          source_rag.ChunkData(
+            content: content,
+            chunkIndex: i,
+            startPos: cursor,
+            endPos: cursor + content.length,
+            chunkType: 'general',
+            embedding: Float32List.fromList([
+              1.0 - (i % 16) * 0.01,
+              (i % 16) * 0.01,
+              0.0,
+              0.0,
+            ]),
+          ),
+        );
+        cursor += content.length + 1;
+      }
+      await source_rag.addChunks(sourceId: source.sourceId, chunks: chunkData);
+      return source.sourceId;
+    }
+
+    try {
+      final scopedSourceId = await seedSource(
+        name: 'scoped',
+        chunkCount: scopedChunkCount,
+        seedBase: 0,
+      );
+      await seedSource(
+        name: 'distractor',
+        chunkCount: distractorChunkCount,
+        seedBase: 7,
+      );
+      await source_rag.rebuildChunkHnswIndexForCollection(
+        collectionId: collectionId,
+      );
+      await source_rag.rebuildChunkBm25IndexForCollection(
+        collectionId: collectionId,
+      );
+
+      final variants = <QueryPayloadVariantStats>[];
+      for (final bm25Weight in bm25Weights) {
+        source_rag.SearchHandle? handle;
+        query_metrics.resetQueryContentReadStats();
+        final sw = Stopwatch()..start();
+        try {
+          handle = await source_rag.searchMetaHybrid(
+            collectionId: collectionId,
+            queryText: queryText,
+            queryEmbedding: queryEmbedding,
+            options: source_rag.SearchMetaHybridOptions(
+              topK: topK,
+              vectorWeight: 1.0 - bm25Weight,
+              bm25Weight: bm25Weight,
+              sourceIds: _toInt64List([scopedSourceId]),
+              adjacentChunks: 0,
+            ),
+          );
+          final hits = await handle.hitMeta();
+          sw.stop();
+          final nativeReadStats = query_metrics.takeQueryContentReadStats();
+
+          variants.add(
+            _variantStatsFromNative(
+              label:
+                  'scoped exact scan (chunks=$scopedChunkCount, bm25=${bm25Weight.toStringAsFixed(2)})',
+              elapsedMs: sw.elapsedMicroseconds / 1000.0,
+              hitCount: hits.length,
+              nativeReadStats: nativeReadStats,
+            ),
+          );
+        } finally {
+          if (handle != null) {
+            await handle.dispose();
+          }
+        }
+      }
+
+      return ScopedExactScanBenchResult(
+        scopedChunkCount: scopedChunkCount,
+        distractorChunkCount: distractorChunkCount,
+        chunkContentBytes: chunkContentChars,
+        topK: topK,
+        bm25Weights: List.unmodifiable(bm25Weights),
+        variants: List.unmodifiable(variants),
       );
     } finally {
       query_metrics.resetQueryContentReadStats();
@@ -1581,6 +1801,52 @@ class IngestLatencyBenchResult {
 
 enum _QueryPayloadHydration { full, preview, contextOnly }
 
+/// Result of [BenchmarkService.benchmarkScopedExactScan].
+///
+/// Captures the scoped exact-scan branch of `searchMetaHybrid`: how many
+/// chunks the backend walks (and how many bytes it reads from `c.content`)
+/// when `source_ids` is set, across the supplied `bm25Weights`. The intent
+/// is to expose whether the SELECT's unconditional `c.content` projection
+/// dominates the scoped path even when BM25 is effectively disabled.
+class ScopedExactScanBenchResult {
+  /// Number of chunks under the scoped `source_ids` filter.
+  final int scopedChunkCount;
+
+  /// Number of chunks on a distractor source kept outside the filter — exists
+  /// purely so the scoped filter has something to exclude.
+  final int distractorChunkCount;
+
+  /// Approximate UTF-8 byte length of each chunk body.
+  final int chunkContentBytes;
+
+  /// `topK` requested per variant.
+  final int topK;
+
+  /// BM25 weights iterated, one entry per [variants].
+  final List<double> bm25Weights;
+
+  /// Captured stats per BM25 weight (aligned with [bm25Weights]).
+  final List<QueryPayloadVariantStats> variants;
+
+  const ScopedExactScanBenchResult({
+    required this.scopedChunkCount,
+    required this.distractorChunkCount,
+    required this.chunkContentBytes,
+    required this.topK,
+    required this.bm25Weights,
+    required this.variants,
+  });
+
+  String renderSummary() {
+    return [
+      'Scoped exact-scan baseline (scoped_chunks=$scopedChunkCount, '
+          'distractor=$distractorChunkCount, '
+          'chunk_body≈${chunkContentBytes}B, topK=$topK):',
+      for (final v in variants) v.renderSummary(),
+    ].join('\n');
+  }
+}
+
 /// Result of [BenchmarkService.benchmarkQueryPayload].
 ///
 /// This is a query-path baseline: it counts UTF-8 bytes of strings surfaced to
@@ -1656,6 +1922,13 @@ class QueryPayloadVariantStats {
   final int nativeUnclassifiedRows;
   final int nativeUnclassifiedContentBytes;
 
+  /// Native rows/bytes the hybrid-search scoped exact-scan path read while
+  /// walking the full scoped chunk set (source_ids / metadata_like branch).
+  /// Disjoint from the materialization counters above — counts backend scan
+  /// work, not result hydration.
+  final int nativeScopedExactScanRows;
+  final int nativeScopedExactScanContentBytes;
+
   const QueryPayloadVariantStats({
     required this.label,
     required this.elapsedMs,
@@ -1674,6 +1947,8 @@ class QueryPayloadVariantStats {
     required this.nativeAssemblyContentBytes,
     required this.nativeUnclassifiedRows,
     required this.nativeUnclassifiedContentBytes,
+    required this.nativeScopedExactScanRows,
+    required this.nativeScopedExactScanContentBytes,
   });
 
   int get totalStringBytes =>
@@ -1708,6 +1983,8 @@ class QueryPayloadVariantStats {
           'full=${fmt(nativeFullHydrateContentBytes)} '
           'preview=${fmt(nativePreviewContentBytes)} '
           'unclassified=${fmt(nativeUnclassifiedContentBytes)}',
+      '    scoped_exact_scan rows=$nativeScopedExactScanRows '
+          'bytes=${fmt(nativeScopedExactScanContentBytes)}',
     ].join('\n');
   }
 }

--- a/lib/src/rust/api/query_metrics.dart
+++ b/lib/src/rust/api/query_metrics.dart
@@ -6,7 +6,7 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `enter`, `record_hybrid_result_content_read`, `record_hydrated_content_read`
+// These functions are ignored because they are not marked as `pub`: `enter`, `record_hybrid_result_content_read`, `record_hydrated_content_read`, `record_scoped_exact_scan_content_read`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `QueryContentReadGuard`, `QueryContentReadPhase`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `clone`, `clone`, `drop`, `eq`, `fmt`, `fmt`
 
@@ -30,6 +30,8 @@ class QueryContentReadStats {
   final BigInt assemblyContentBytes;
   final BigInt unclassifiedRows;
   final BigInt unclassifiedContentBytes;
+  final BigInt scopedExactScanRows;
+  final BigInt scopedExactScanContentBytes;
 
   const QueryContentReadStats({
     required this.hybridResultRows,
@@ -42,8 +44,11 @@ class QueryContentReadStats {
     required this.assemblyContentBytes,
     required this.unclassifiedRows,
     required this.unclassifiedContentBytes,
+    required this.scopedExactScanRows,
+    required this.scopedExactScanContentBytes,
   });
 
+  /// Materialized result bytes only — see [`Self::rows_total`].
   Future<BigInt> contentBytesTotal() => RustLib.instance.api
       .crateApiQueryMetricsQueryContentReadStatsContentBytesTotal(that: this);
 
@@ -55,6 +60,9 @@ class QueryContentReadStats {
   Future<BigInt> hydrationRowsTotal() => RustLib.instance.api
       .crateApiQueryMetricsQueryContentReadStatsHydrationRowsTotal(that: this);
 
+  /// Materialized result reads only — does NOT include the scoped exact-scan
+  /// backend counter, which measures rows scanned during search rather than
+  /// rows surfaced as results.
   Future<BigInt> rowsTotal() => RustLib.instance.api
       .crateApiQueryMetricsQueryContentReadStatsRowsTotal(that: this);
 
@@ -69,7 +77,9 @@ class QueryContentReadStats {
       assemblyRows.hashCode ^
       assemblyContentBytes.hashCode ^
       unclassifiedRows.hashCode ^
-      unclassifiedContentBytes.hashCode;
+      unclassifiedContentBytes.hashCode ^
+      scopedExactScanRows.hashCode ^
+      scopedExactScanContentBytes.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -85,5 +95,7 @@ class QueryContentReadStats {
           assemblyRows == other.assemblyRows &&
           assemblyContentBytes == other.assemblyContentBytes &&
           unclassifiedRows == other.unclassifiedRows &&
-          unclassifiedContentBytes == other.unclassifiedContentBytes;
+          unclassifiedContentBytes == other.unclassifiedContentBytes &&
+          scopedExactScanRows == other.scopedExactScanRows &&
+          scopedExactScanContentBytes == other.scopedExactScanContentBytes;
 }

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -5889,8 +5889,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   QueryContentReadStats dco_decode_query_content_read_stats(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 10)
-      throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+    if (arr.length != 12)
+      throw Exception('unexpected arr length: expect 12 but see ${arr.length}');
     return QueryContentReadStats(
       hybridResultRows: dco_decode_u_64(arr[0]),
       hybridResultContentBytes: dco_decode_u_64(arr[1]),
@@ -5902,6 +5902,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       assemblyContentBytes: dco_decode_u_64(arr[7]),
       unclassifiedRows: dco_decode_u_64(arr[8]),
       unclassifiedContentBytes: dco_decode_u_64(arr[9]),
+      scopedExactScanRows: dco_decode_u_64(arr[10]),
+      scopedExactScanContentBytes: dco_decode_u_64(arr[11]),
     );
   }
 
@@ -7201,6 +7203,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_assemblyContentBytes = sse_decode_u_64(deserializer);
     var var_unclassifiedRows = sse_decode_u_64(deserializer);
     var var_unclassifiedContentBytes = sse_decode_u_64(deserializer);
+    var var_scopedExactScanRows = sse_decode_u_64(deserializer);
+    var var_scopedExactScanContentBytes = sse_decode_u_64(deserializer);
     return QueryContentReadStats(
       hybridResultRows: var_hybridResultRows,
       hybridResultContentBytes: var_hybridResultContentBytes,
@@ -7212,6 +7216,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       assemblyContentBytes: var_assemblyContentBytes,
       unclassifiedRows: var_unclassifiedRows,
       unclassifiedContentBytes: var_unclassifiedContentBytes,
+      scopedExactScanRows: var_scopedExactScanRows,
+      scopedExactScanContentBytes: var_scopedExactScanContentBytes,
     );
   }
 
@@ -8477,6 +8483,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_u_64(self.assemblyContentBytes, serializer);
     sse_encode_u_64(self.unclassifiedRows, serializer);
     sse_encode_u_64(self.unclassifiedContentBytes, serializer);
+    sse_encode_u_64(self.scopedExactScanRows, serializer);
+    sse_encode_u_64(self.scopedExactScanContentBytes, serializer);
   }
 
   @protected

--- a/rust_builder/rust/src/api/hybrid_search.rs
+++ b/rust_builder/rust/src/api/hybrid_search.rs
@@ -23,7 +23,9 @@ use crate::api::bm25_search::{bm25_search, tokenize_for_bm25, Bm25SearchResult};
 use crate::api::db_pool::get_connection;
 use crate::api::error::RagError;
 use crate::api::hnsw_index::{is_hnsw_index_loaded, search_hnsw_slice, HnswSearchResult};
-use crate::api::query_metrics::record_hybrid_result_content_read;
+use crate::api::query_metrics::{
+    record_hybrid_result_content_read, record_scoped_exact_scan_content_read,
+};
 use crate::api::vector_math::{cosine_with_query_norm_f32, decode_f32_embedding, l2_norm_f32};
 #[cfg(feature = "vector_quant_i8")]
 use crate::api::vector_quant::{cosine_with_query_norm_i8_blob, l2_norm_i8, quantize_f32_to_i8};
@@ -211,21 +213,44 @@ fn compute_hybrid_rrf_scores(
                 exact_conditions.push(format!("s.metadata LIKE '{}'", pattern.replace("'", "''")));
             }
 
+            // Tokenize the query first so we can decide whether the scoped
+            // BM25 leg actually needs chunk bodies. When `bm25_weight == 0`
+            // (or no query tokens survive normalization) BM25 contributes
+            // nothing to the final RRF score, so reading `c.content` for
+            // every scoped chunk is pure I/O waste. Elide the column from
+            // the SELECT in that case; row reader treats column 3 as
+            // `Option<String>` either way.
+            //
+            // Note: `!= 0.0` (not `> 0.0`) — preserves prior behavior for any
+            // non-zero weight, including negative values that callers might
+            // pass. RRF still applies the (potentially negative) weight; we
+            // only short-circuit when the contribution is provably zero.
+            let query_tokens = tokenize_for_bm25(&query_text);
+            let query_token_set: HashSet<String> = query_tokens.iter().cloned().collect();
+            let need_bm25 = config.bm25_weight != 0.0 && !query_token_set.is_empty();
+            let content_projection = if need_bm25 {
+                "c.content"
+            } else {
+                "NULL AS content"
+            };
+
             // Fetch ALL chunks for this scoped set for exact vector + BM25 scoring.
             let query_with_i8 = format!(
-                "SELECT c.id, c.embedding, {}, c.content
+                "SELECT c.id, c.embedding, {}, {}
                      FROM chunks c
                      LEFT JOIN sources s ON c.source_id = s.id
                      WHERE {}",
                 "c.embedding_i8",
+                content_projection,
                 exact_conditions.join(" AND ")
             );
             let query_without_i8 = format!(
-                "SELECT c.id, c.embedding, {}, c.content
+                "SELECT c.id, c.embedding, {}, {}
                      FROM chunks c
                      LEFT JOIN sources s ON c.source_id = s.id
                      WHERE {}",
                 "NULL AS embedding_i8",
+                content_projection,
                 exact_conditions.join(" AND ")
             );
 
@@ -241,7 +266,7 @@ fn compute_hybrid_rrf_scores(
                         row.get::<_, i64>(0)?,
                         row.get::<_, Vec<u8>>(1)?,
                         row.get::<_, Option<Vec<u8>>>(2)?,
-                        row.get::<_, String>(3)?,
+                        row.get::<_, Option<String>>(3)?,
                     ))
                 })
                 .map_err(|e| RagError::DatabaseError(e.to_string()))?;
@@ -251,8 +276,6 @@ fn compute_hybrid_rrf_scores(
             let (query_i8, _query_i8_scale) = quantize_f32_to_i8(query_embedding);
             #[cfg(feature = "vector_quant_i8")]
             let query_i8_norm = l2_norm_i8(&query_i8);
-            let query_tokens = tokenize_for_bm25(&query_text);
-            let query_token_set: HashSet<String> = query_tokens.iter().cloned().collect();
 
             let mut scoped_doc_count = 0usize;
             let mut scoped_total_doc_length = 0usize;
@@ -266,6 +289,13 @@ fn compute_hybrid_rrf_scores(
 
             for row in chunk_iter {
                 if let Ok((id, embedding_blob, embedding_i8_blob, content)) = row {
+                    // Only count what we actually read. When `need_bm25` is
+                    // false the SELECT projects NULL for column 3 and the
+                    // counter stays at zero — which is the whole point of
+                    // the projection elision.
+                    if let Some(ref content_str) = content {
+                        record_scoped_exact_scan_content_read(content_str.len() as u64);
+                    }
                     #[cfg(not(feature = "vector_quant_i8"))]
                     let _ = &embedding_i8_blob;
                     #[cfg(feature = "vector_quant_i8")]
@@ -304,25 +334,27 @@ fn compute_hybrid_rrf_scores(
                         distance: (1.0 - sim) as f32, // lower is better
                     });
 
-                    if !query_token_set.is_empty() {
-                        let doc_tokens = tokenize_for_bm25(&content);
-                        let doc_length = doc_tokens.len();
-                        if doc_length > 0 {
-                            scoped_doc_count += 1;
-                            scoped_total_doc_length += doc_length;
-                            scoped_doc_lengths.insert(id, doc_length);
+                    if need_bm25 {
+                        if let Some(content_str) = content {
+                            let doc_tokens = tokenize_for_bm25(&content_str);
+                            let doc_length = doc_tokens.len();
+                            if doc_length > 0 {
+                                scoped_doc_count += 1;
+                                scoped_total_doc_length += doc_length;
+                                scoped_doc_lengths.insert(id, doc_length);
 
-                            let mut term_freqs: HashMap<String, u32> = HashMap::new();
-                            for token in doc_tokens {
-                                if query_token_set.contains(&token) {
-                                    *term_freqs.entry(token).or_insert(0) += 1;
+                                let mut term_freqs: HashMap<String, u32> = HashMap::new();
+                                for token in doc_tokens {
+                                    if query_token_set.contains(&token) {
+                                        *term_freqs.entry(token).or_insert(0) += 1;
+                                    }
                                 }
-                            }
-                            for term in term_freqs.keys() {
-                                *scoped_doc_freqs.entry(term.clone()).or_insert(0) += 1;
-                            }
-                            if !term_freqs.is_empty() {
-                                scoped_term_freqs.insert(id, term_freqs);
+                                for term in term_freqs.keys() {
+                                    *scoped_doc_freqs.entry(term.clone()).or_insert(0) += 1;
+                                }
+                                if !term_freqs.is_empty() {
+                                    scoped_term_freqs.insert(id, term_freqs);
+                                }
                             }
                         }
                     }
@@ -337,7 +369,7 @@ fn compute_hybrid_rrf_scores(
             });
             vector_results.truncate(candidate_k);
 
-            if !query_tokens.is_empty() && scoped_doc_count > 0 {
+            if need_bm25 && scoped_doc_count > 0 {
                 let avg_doc_length = scoped_total_doc_length as f64 / scoped_doc_count as f64;
                 let k1 = 1.2;
                 let b = 0.75;
@@ -525,13 +557,8 @@ pub(crate) fn search_hybrid_inner(
     config: Option<RrfConfig>,
     filter: Option<SearchFilter>,
 ) -> Result<Vec<HybridSearchResult>, RagError> {
-    let (rrf_scores, filter) = compute_hybrid_rrf_scores(
-        query_text,
-        query_embedding,
-        top_k,
-        config,
-        filter,
-    )?;
+    let (rrf_scores, filter) =
+        compute_hybrid_rrf_scores(query_text, query_embedding, top_k, config, filter)?;
 
     // 4. Batch Content Fetch
     if rrf_scores.is_empty() {
@@ -640,13 +667,8 @@ pub(crate) fn search_hybrid_meta_inner(
     config: Option<RrfConfig>,
     filter: Option<SearchFilter>,
 ) -> Result<Vec<HybridSearchMeta>, RagError> {
-    let (rrf_scores, filter) = compute_hybrid_rrf_scores(
-        query_text,
-        query_embedding,
-        top_k,
-        config,
-        filter,
-    )?;
+    let (rrf_scores, filter) =
+        compute_hybrid_rrf_scores(query_text, query_embedding, top_k, config, filter)?;
 
     if rrf_scores.is_empty() {
         return Ok(vec![]);
@@ -764,6 +786,7 @@ mod tests {
     use crate::api::bm25_search::{bm25_add_document, bm25_clear_index};
     use crate::api::db_pool::{close_db_pool, get_connection, init_db_pool};
     use crate::api::hnsw_index::{build_hnsw_index, clear_hnsw_index};
+    use crate::api::query_metrics::{query_content_read_stats, reset_query_content_read_stats};
     use crate::api::simple_rag::init_db;
     use crate::api::source_rag::init_source_db;
     use rusqlite::params;
@@ -977,6 +1000,120 @@ mod tests {
         .unwrap();
 
         assert!(results.is_empty());
+
+        close_db_pool();
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn test_scoped_exact_scan_skips_content_when_bm25_disabled() {
+        let db_path = std::env::temp_dir().join("test_hybrid_scoped_exact_scan_skips_content.db");
+        let _ = std::fs::remove_file(&db_path);
+
+        init_db_pool(db_path.to_str().unwrap().to_string(), 1).unwrap();
+        init_source_db().unwrap();
+        clear_hnsw_index();
+        bm25_clear_index();
+
+        {
+            let conn = get_connection().unwrap();
+            conn.execute(
+                "INSERT INTO sources (id, content, content_hash, metadata, name, status) VALUES (1, 's1', 'h_s1', NULL, 'source-1', 'completed')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO chunks (id, source_id, chunk_index, content, start_pos, end_pos, chunk_type, embedding)
+                 VALUES (?1, 1, 0, ?2, 0, 1024, 'general', ?3)",
+                params![
+                    101_i64,
+                    "apple ".repeat(64),
+                    embedding_to_blob(&[1.0_f32, 0.0_f32]),
+                ],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO chunks (id, source_id, chunk_index, content, start_pos, end_pos, chunk_type, embedding)
+                 VALUES (?1, 1, 1, ?2, 1024, 2048, 'general', ?3)",
+                params![
+                    102_i64,
+                    "banana ".repeat(64),
+                    embedding_to_blob(&[0.0_f32, 1.0_f32]),
+                ],
+            )
+            .unwrap();
+        }
+
+        // BM25 disabled: scoped scan should NOT pull chunk bodies, so the
+        // counter must stay at zero even though both rows match the scope.
+        reset_query_content_read_stats();
+        let zero_results = search_hybrid(
+            "apple".to_string(),
+            vec![1.0, 0.0],
+            2,
+            Some(RrfConfig {
+                k: 60,
+                vector_weight: 1.0,
+                bm25_weight: 0.0,
+            }),
+            Some(SearchFilter {
+                source_ids: Some(vec![1]),
+                metadata_like: None,
+                collection_id: None,
+            }),
+        )
+        .unwrap();
+        let zero_stats = query_content_read_stats();
+        assert_eq!(
+            zero_stats.scoped_exact_scan_rows, 0,
+            "bm25_weight=0 must elide the content projection (rows counter must stay 0)"
+        );
+        assert_eq!(
+            zero_stats.scoped_exact_scan_content_bytes, 0,
+            "bm25_weight=0 must elide the content projection (bytes counter must stay 0)"
+        );
+        assert_eq!(zero_results.len(), 2);
+        let zero_top_id = zero_results
+            .iter()
+            .max_by(|a, b| a.score.partial_cmp(&b.score).unwrap())
+            .map(|r| r.doc_id)
+            .unwrap();
+
+        // BM25 enabled: scoped scan must pull bodies, so the counter has to
+        // record at least the combined chunk content length.
+        reset_query_content_read_stats();
+        let bm25_results = search_hybrid(
+            "apple".to_string(),
+            vec![1.0, 0.0],
+            2,
+            Some(RrfConfig {
+                k: 60,
+                vector_weight: 0.5,
+                bm25_weight: 0.5,
+            }),
+            Some(SearchFilter {
+                source_ids: Some(vec![1]),
+                metadata_like: None,
+                collection_id: None,
+            }),
+        )
+        .unwrap();
+        let bm25_stats = query_content_read_stats();
+        assert_eq!(bm25_stats.scoped_exact_scan_rows, 2);
+        assert!(
+            bm25_stats.scoped_exact_scan_content_bytes
+                >= ("apple ".len() * 64) as u64 + ("banana ".len() * 64) as u64,
+            "bm25_weight>0 must read both chunk bodies (got {} bytes)",
+            bm25_stats.scoped_exact_scan_content_bytes
+        );
+
+        // Vector-only ranking must still agree on the "apple" chunk being
+        // top-ranked even when content was elided.
+        assert_eq!(
+            zero_top_id, 101,
+            "elided projection must not change ranking"
+        );
+        assert!(bm25_results.iter().any(|r| r.doc_id == 101));
 
         close_db_pool();
         let _ = std::fs::remove_file(db_path);

--- a/rust_builder/rust/src/api/query_metrics.rs
+++ b/rust_builder/rust/src/api/query_metrics.rs
@@ -78,6 +78,7 @@ static FULL_HYDRATE_CONTENT: AtomicCounter = AtomicCounter::new();
 static PREVIEW_CONTENT: AtomicCounter = AtomicCounter::new();
 static ASSEMBLY_CONTENT: AtomicCounter = AtomicCounter::new();
 static UNCLASSIFIED_CONTENT: AtomicCounter = AtomicCounter::new();
+static SCOPED_EXACT_SCAN_CONTENT: AtomicCounter = AtomicCounter::new();
 
 /// Record content read by `hybrid_search` while materializing legacy
 /// `HybridSearchResult.content`.
@@ -95,6 +96,17 @@ pub(crate) fn record_hydrated_content_read(content_bytes: u64) {
     });
 }
 
+/// Record content read by the hybrid-search scoped exact-scan path (the
+/// `source_ids` / `metadata_like` branch that walks the entire scoped chunk
+/// set to compute scoped BM25). Counted per row regardless of whether the
+/// chunk ends up in the final top-K; this is the "backend scan cost"
+/// counter and is intentionally orthogonal to the materialization counters
+/// above (a scoped chunk that survives RRF will also show up in
+/// `hybrid_result_*` or `full_hydrate_*` when its body is later returned).
+pub(crate) fn record_scoped_exact_scan_content_read(content_bytes: u64) {
+    SCOPED_EXACT_SCAN_CONTENT.record(content_bytes);
+}
+
 #[derive(Debug, Clone)]
 pub struct QueryContentReadStats {
     pub hybrid_result_rows: u64,
@@ -107,6 +119,8 @@ pub struct QueryContentReadStats {
     pub assembly_content_bytes: u64,
     pub unclassified_rows: u64,
     pub unclassified_content_bytes: u64,
+    pub scoped_exact_scan_rows: u64,
+    pub scoped_exact_scan_content_bytes: u64,
 }
 
 impl QueryContentReadStats {
@@ -121,10 +135,14 @@ impl QueryContentReadStats {
             + self.unclassified_content_bytes
     }
 
+    /// Materialized result reads only — does NOT include the scoped exact-scan
+    /// backend counter, which measures rows scanned during search rather than
+    /// rows surfaced as results.
     pub fn rows_total(&self) -> u64 {
         self.hybrid_result_rows + self.hydration_rows_total()
     }
 
+    /// Materialized result bytes only — see [`Self::rows_total`].
     pub fn content_bytes_total(&self) -> u64 {
         self.hybrid_result_content_bytes + self.hydration_content_bytes_total()
     }
@@ -137,6 +155,7 @@ pub fn query_content_read_stats() -> QueryContentReadStats {
     let (preview_rows, preview_bytes) = PREVIEW_CONTENT.snapshot();
     let (assembly_rows, assembly_bytes) = ASSEMBLY_CONTENT.snapshot();
     let (unclassified_rows, unclassified_bytes) = UNCLASSIFIED_CONTENT.snapshot();
+    let (scoped_rows, scoped_bytes) = SCOPED_EXACT_SCAN_CONTENT.snapshot();
     QueryContentReadStats {
         hybrid_result_rows: hybrid_rows,
         hybrid_result_content_bytes: hybrid_bytes,
@@ -148,6 +167,8 @@ pub fn query_content_read_stats() -> QueryContentReadStats {
         assembly_content_bytes: assembly_bytes,
         unclassified_rows,
         unclassified_content_bytes: unclassified_bytes,
+        scoped_exact_scan_rows: scoped_rows,
+        scoped_exact_scan_content_bytes: scoped_bytes,
     }
 }
 
@@ -158,6 +179,7 @@ pub fn reset_query_content_read_stats() {
     PREVIEW_CONTENT.reset();
     ASSEMBLY_CONTENT.reset();
     UNCLASSIFIED_CONTENT.reset();
+    SCOPED_EXACT_SCAN_CONTENT.reset();
 }
 
 #[frb(sync)]

--- a/rust_builder/rust/src/frb_generated.rs
+++ b/rust_builder/rust/src/frb_generated.rs
@@ -5984,6 +5984,8 @@ impl SseDecode for crate::api::query_metrics::QueryContentReadStats {
         let mut var_assemblyContentBytes = <u64>::sse_decode(deserializer);
         let mut var_unclassifiedRows = <u64>::sse_decode(deserializer);
         let mut var_unclassifiedContentBytes = <u64>::sse_decode(deserializer);
+        let mut var_scopedExactScanRows = <u64>::sse_decode(deserializer);
+        let mut var_scopedExactScanContentBytes = <u64>::sse_decode(deserializer);
         return crate::api::query_metrics::QueryContentReadStats {
             hybrid_result_rows: var_hybridResultRows,
             hybrid_result_content_bytes: var_hybridResultContentBytes,
@@ -5995,6 +5997,8 @@ impl SseDecode for crate::api::query_metrics::QueryContentReadStats {
             assembly_content_bytes: var_assemblyContentBytes,
             unclassified_rows: var_unclassifiedRows,
             unclassified_content_bytes: var_unclassifiedContentBytes,
+            scoped_exact_scan_rows: var_scopedExactScanRows,
+            scoped_exact_scan_content_bytes: var_scopedExactScanContentBytes,
         };
     }
 }
@@ -7124,6 +7128,10 @@ impl flutter_rust_bridge::IntoDart for crate::api::query_metrics::QueryContentRe
             self.assembly_content_bytes.into_into_dart().into_dart(),
             self.unclassified_rows.into_into_dart().into_dart(),
             self.unclassified_content_bytes.into_into_dart().into_dart(),
+            self.scoped_exact_scan_rows.into_into_dart().into_dart(),
+            self.scoped_exact_scan_content_bytes
+                .into_into_dart()
+                .into_dart(),
         ]
         .into_dart()
     }
@@ -8136,6 +8144,8 @@ impl SseEncode for crate::api::query_metrics::QueryContentReadStats {
         <u64>::sse_encode(self.assembly_content_bytes, serializer);
         <u64>::sse_encode(self.unclassified_rows, serializer);
         <u64>::sse_encode(self.unclassified_content_bytes, serializer);
+        <u64>::sse_encode(self.scoped_exact_scan_rows, serializer);
+        <u64>::sse_encode(self.scoped_exact_scan_content_bytes, serializer);
     }
 }
 

--- a/test/native/scoped_exact_scan_bench_test.dart
+++ b/test/native/scoped_exact_scan_bench_test.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_rag_engine/services/benchmark_service.dart';
+import 'package:mobile_rag_engine/src/rust/frb_generated.dart';
+
+Future<void> _ensureRustLoaded() async {
+  if (!RustLib.instance.initialized) {
+    await RustLib.init();
+  }
+}
+
+void main() {
+  setUpAll(() async {
+    await _ensureRustLoaded();
+  });
+
+  test('scoped exact-scan elides content when bm25_weight is 0', () async {
+    final dir = await Directory.systemTemp.createTemp(
+      'mobile_rag_scoped_exact_scan_',
+    );
+    try {
+      const chunkBytes = 256;
+
+      final small = await BenchmarkService.benchmarkScopedExactScan(
+        scopedChunkCount: 50,
+        distractorChunkCount: 10,
+        chunkContentChars: chunkBytes,
+        topK: 4,
+        bm25Weights: const [0.0, 0.5],
+        dbPathOverride: '${dir.path}/scoped_50.sqlite',
+      );
+
+      expect(small.variants, hasLength(2));
+
+      // bm25_weight=0 → SELECT elides c.content, counter stays at 0.
+      final smallZero = small.variants[0];
+      expect(smallZero.nativeScopedExactScanRows, 0);
+      expect(smallZero.nativeScopedExactScanContentBytes, 0);
+
+      // bm25_weight>0 → every scoped chunk body is read.
+      final smallBm25 = small.variants[1];
+      expect(smallBm25.nativeScopedExactScanRows, small.scopedChunkCount);
+      expect(
+        smallBm25.nativeScopedExactScanContentBytes,
+        greaterThanOrEqualTo(small.scopedChunkCount * chunkBytes),
+      );
+
+      final large = await BenchmarkService.benchmarkScopedExactScan(
+        scopedChunkCount: 500,
+        distractorChunkCount: 10,
+        chunkContentChars: chunkBytes,
+        topK: 4,
+        bm25Weights: const [0.0, 0.5],
+        dbPathOverride: '${dir.path}/scoped_500.sqlite',
+      );
+
+      expect(large.variants, hasLength(2));
+      final largeZero = large.variants[0];
+      expect(largeZero.nativeScopedExactScanRows, 0);
+      expect(largeZero.nativeScopedExactScanContentBytes, 0);
+
+      final largeBm25 = large.variants[1];
+      expect(largeBm25.nativeScopedExactScanRows, large.scopedChunkCount);
+      expect(
+        largeBm25.nativeScopedExactScanContentBytes,
+        greaterThanOrEqualTo(large.scopedChunkCount * chunkBytes),
+      );
+
+      // 10× scope → ≥ 10× scoped-scan bytes for the bm25-on path.
+      expect(
+        largeBm25.nativeScopedExactScanContentBytes,
+        greaterThanOrEqualTo(smallBm25.nativeScopedExactScanContentBytes * 10),
+      );
+
+      // searchMetaHybrid is meta-only: no result body is materialized.
+      for (final v in [...small.variants, ...large.variants]) {
+        expect(v.nativeHybridResultContentBytes, 0);
+        expect(v.nativeFullHydrateContentBytes, 0);
+      }
+
+      // ignore: avoid_print
+      print(small.renderSummary());
+      // ignore: avoid_print
+      print(large.renderSummary());
+    } finally {
+      await dir.delete(recursive: true);
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- add a scoped exact-scan content-read counter to query metrics
- elide `c.content` from the scoped exact-scan SQL projection when BM25 cannot affect RRF scoring
- add a native benchmark covering 50/500 scoped chunks with BM25 disabled/enabled
- document the P0 optimization and measured effect

## Why

The `source_ids` / `metadata_like` exact-scan path walked every scoped chunk and read `c.content` even when `bm25_weight == 0`. That made query cost scale with the full scoped set despite the content bytes being unused. This keeps vector-only scoped searches body-free and leaves BM25-enabled behavior unchanged.

## Validation

- `flutter analyze lib/services/benchmark_service.dart test/native/scoped_exact_scan_bench_test.dart test/native/query_payload_bench_test.dart`
- `cargo test --release --manifest-path rust_builder/rust/Cargo.toml hybrid_search -- --test-threads=1`
- `cargo test --release --manifest-path rust_builder/rust/Cargo.toml source_rag -- --test-threads=1`
- `flutter test test/native/scoped_exact_scan_bench_test.dart --reporter expanded`
- `flutter test test/native/query_payload_bench_test.dart --reporter expanded`

## Measured Fixture

- 50 chunks, BM25 off: `0 rows / 0 KB`
- 50 chunks, BM25 on: `50 rows / 12.5 KB`
- 500 chunks, BM25 off: `0 rows / 0 KB`
- 500 chunks, BM25 on: `500 rows / 125.0 KB`
