### PR TITLE
chore: publish 0.18.4 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.18.4
 * **Retrieval hot path**:
   - Scoped source/metadata hybrid searches now preserve BM25 ranks through the active collection BM25 term index instead of reading and tokenizing every scoped chunk body at query time.
   - Updated scoped exact-scan benchmarks to assert zero query-time body reads and zero body tokenization for both vector-only and BM25-on scoped paths.
+* **Compatibility**:
+  - Bumped dependency constraint to `rag_engine_flutter: ^0.18.2` so consumers receive the matching native scoped BM25 search implementation.
 
 ## 0.18.3
 * **Documentation**:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -206,7 +206,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.18.3"
+    version: "0.18.4"
   onnxruntime:
     dependency: transitive
     description:
@@ -293,7 +293,7 @@ packages:
       path: "../rust_builder"
       relative: true
     source: path
-    version: "0.18.1"
+    version: "0.18.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -479,10 +479,10 @@ packages:
     dependency: "direct main"
     description:
       name: rag_engine_flutter
-      sha256: ba65e620d2b825c4f23a801d1593df338e9a3e1d5b6239911364055c54590529
+      sha256: f499d25ced5a81d2f00024a442d32520698cd61b17b15b74661080f40b3088b0
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.18.2"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_rag_engine
 description: A high-performance, on-device RAG (Retrieval-Augmented Generation) engine for Flutter. Run semantic search completely offline on iOS, Android, and macOS with HNSW vector indexing.
-version: 0.18.3
+version: 0.18.4
 homepage: https://github.com/dev07060/mobile_rag_engine
 repository: https://github.com/dev07060/mobile_rag_engine
 issue_tracker: https://github.com/dev07060/mobile_rag_engine/issues
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_rust_bridge: ^2.11.1
-  rag_engine_flutter: ^0.18.1
+  rag_engine_flutter: ^0.18.2
   path_provider: ^2.1.5
   onnxruntime: ^1.4.1
   freezed_annotation: ^3.1.0

--- a/rust_builder/CHANGELOG.md
+++ b/rust_builder/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.18.2
 * **Scoped BM25 search**:
   - Added scoped BM25 ranking over the existing in-memory inverted index, restricted by the scoped chunk ids collected during exact vector scan.
   - Removed query-time chunk-body reads/tokenization from the source/metadata scoped exact-scan path when BM25 is enabled.

--- a/rust_builder/pubspec.yaml
+++ b/rust_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: rag_engine_flutter
 description: >
   Native Rust FFI plugin for mobile_rag_engine. Provides high-performance
   tokenization and HNSW vector indexing for on-device RAG.
-version: 0.18.1
+version: 0.18.2
 homepage: https://github.com/dev07060/mobile_rag_engine
 repository: https://github.com/dev07060/mobile_rag_engine
 issue_tracker: https://github.com/dev07060/mobile_rag_engine/issues


### PR DESCRIPTION
## Summary

- Prepare `rag_engine_flutter` `0.18.2` release metadata for the native scoped BM25 implementation.
- Prepare `mobile_rag_engine` `0.18.4` release metadata and lockfiles.
- Bump the root package dependency to `rag_engine_flutter: ^0.18.2` so consumers resolve the matching native package.

## Published

- `rag_engine_flutter 0.18.2` published to pub.dev.
- `mobile_rag_engine 0.18.4` published to pub.dev.

## Validation

- PR #52 CI was green before release: Analyze + Unit, Native Tests macOS, Integration Tests macOS, and build smoke checks for Android/iOS/macOS.
- `flutter pub publish --dry-run` passed with 0 warnings for `rust_builder`.
- `flutter pub publish --dry-run` passed with 0 warnings for the root package.
- pub.dev API reports `rag_engine_flutter latest=0.18.2` and `mobile_rag_engine latest=0.18.4`.

## Notes

- Direct push to `main` is blocked by repository rules, so these release-record commits are submitted through this PR after publishing.