### PR TITLE
feat(migration): embedding fingerprint mismatch gate (P0-2)

### DIFF
--- a/lib/mobile_rag.dart
+++ b/lib/mobile_rag.dart
@@ -44,6 +44,8 @@ import 'package:mobile_rag_engine/src/rust/api/source_rag.dart'
 import 'package:mobile_rag_engine/src/rust/api/hybrid_search.dart' as hybrid;
 
 // Export types for consumers
+export 'package:mobile_rag_engine/src/internal/embedding_fingerprint.dart'
+    show ClearAndRestartConfirmation, RagEmbeddingFingerprintLock, RagReembedProgress;
 export 'package:mobile_rag_engine/src/rust/api/migration_meta.dart'
     show MigrationAxes;
 export 'package:mobile_rag_engine/src/rust/api/source_rag.dart'
@@ -191,11 +193,65 @@ class MobileRag {
   /// Whether all retrieval indexes are ready for full-quality search.
   bool get isIndexReady => _engine!.isIndexReady;
 
-  /// Read-only snapshot of the four on-device data migration axes
+  /// Read-only snapshot of every on-device data migration axis
   /// (`sql_schema_version`, `hnsw_format_version`, `bm25_stats_version`,
-  /// `embedding_fingerprint`) plus the last engine version recorded at boot.
-  /// Backed by the `migration_meta` row provisioned during `initialize()`.
+  /// `embedding_fingerprint`, `embedding_fingerprint_pending`) plus the last
+  /// engine version recorded at boot. Backed by the `migration_meta` row
+  /// provisioned during `initialize()`.
   Future<MigrationAxes> get migrationState => _engine!.migrationState;
+
+  /// Fingerprint computed from the currently loaded embedding model
+  /// (`{modelBasename}|{dim}|{quant}`). Stable across reboots as long as the
+  /// host app keeps loading the same model file.
+  String get currentEmbeddingFingerprint =>
+      _engine!.currentEmbeddingFingerprint;
+
+  /// Non-null when boot detected an embedding fingerprint mismatch — i.e.
+  /// the stored on-device embeddings were produced by a different model than
+  /// the one currently loaded. While set, all search and ingest entry points
+  /// throw `RagError.embeddingFingerprintMismatch`. Resolve by calling either
+  /// [reembedAll] (preserves data) or [clearAndRestart] (discards embeddings
+  /// after explicit confirmation).
+  RagEmbeddingFingerprintLock? get embeddingFingerprintLock =>
+      _engine!.embeddingFingerprintLock;
+
+  /// Whether boot detected an embedding fingerprint mismatch.
+  bool get isEmbeddingFingerprintLocked =>
+      _engine!.isEmbeddingFingerprintLocked;
+
+  /// Re-embed every stored chunk with the currently loaded model and clear
+  /// the [embeddingFingerprintLock]. Resumable across app restarts — progress
+  /// is persisted per chunk on the Rust side, so an interrupted run picks up
+  /// where it left off on the next call.
+  ///
+  /// [onProgress] is invoked once per chunk with the cumulative
+  /// (done, total) snapshot for the current run.
+  ///
+  /// Throws [StateError] when no mismatch is active.
+  Future<void> reembedAll({
+    void Function(RagReembedProgress progress)? onProgress,
+    int batchSize = 32,
+  }) =>
+      _engine!.reembedAll(onProgress: onProgress, batchSize: batchSize);
+
+  /// Discard every on-device embedding (chunks table) and rotate the
+  /// fingerprint baseline to the currently loaded model.
+  ///
+  /// `confirm` is required and only accepts
+  /// [ClearAndRestartConfirmation.iUnderstandThisDeletesAllOnDeviceEmbeddings]
+  /// — the parameter exists solely to keep the destructive choice visible at
+  /// every call site. The `sources` table is preserved so the original
+  /// documents can be re-ingested through `addDocument`.
+  ///
+  /// Throws [StateError] when no mismatch is active.
+  Future<void> clearAndRestart({
+    required ClearAndRestartConfirmation confirm,
+  }) =>
+      _engine!.clearAndRestart(confirm: confirm);
+
+  /// Up-to-date count of chunks still tagged with a non-current fingerprint.
+  /// Safe to call while [reembedAll] is running.
+  Future<int> reembedRemaining() => _engine!.reembedRemaining();
 
   /// Completes when BM25/HNSW warmup has finished.
   Future<void> get warmupFuture => _engine!.warmupFuture;

--- a/lib/services/rag_engine.dart
+++ b/lib/services/rag_engine.dart
@@ -43,9 +43,31 @@ import '../src/rust/api/source_rag.dart'
         ChunkExcerptResult,
         AssembledContextV2;
 import '../src/rust/api/db_pool.dart';
-import '../src/rust/api/migration_meta.dart' show MigrationAxes, readMigrationAxes;
+import '../src/rust/api/error.dart';
+import '../src/rust/api/migration_meta.dart' as migration_meta
+    show
+        EmbeddingFingerprintGate_Mismatch,
+        EmbeddingFingerprintGate_Ok,
+        EmbeddingFingerprintGate_RequiresInitialBaseline,
+        MigrationAxes,
+        acknowledgeAndClearEmbeddings,
+        beginEmbeddingReembed,
+        countChunksNeedingReembed,
+        detectEmbeddingFingerprintGate,
+        finalizeEmbeddingReembed,
+        readMigrationAxes,
+        writeEmbeddingFingerprint;
+import '../src/rust/api/source_rag.dart' as rust_rag
+    show listChunksNeedingReembed, updateChunkReembedded;
 import '../src/internal/defaults.dart';
+import '../src/internal/embedding_fingerprint.dart';
 import '../src/internal/validation.dart';
+
+export '../src/internal/embedding_fingerprint.dart'
+    show
+        ClearAndRestartConfirmation,
+        RagEmbeddingFingerprintLock,
+        RagReembedProgress;
 import 'embedding_service.dart';
 import 'rag_config.dart';
 import 'source_rag_service.dart';
@@ -86,18 +108,53 @@ class RagEngine {
   final int vocabSize;
   final bool _deferIndexWarmup;
 
+  /// Fingerprint of the currently loaded embedding model.
+  /// Captured during [initialize] via a one-shot probe embed.
+  final String currentEmbeddingFingerprint;
+
+  /// Non-null when boot detected an embedding fingerprint mismatch.
+  /// All search and ingest entry points must throw
+  /// `RagError.embeddingFingerprintMismatch` until the host app resolves it
+  /// via [reembedAll] or [clearAndRestart].
+  RagEmbeddingFingerprintLock? _fingerprintLock;
+
   RagEngine._({
     required SourceRagService ragService,
     required this.dbPath,
     required this.vocabSize,
+    required this.currentEmbeddingFingerprint,
+    required RagEmbeddingFingerprintLock? initialLock,
     required bool deferIndexWarmup,
   })  : _ragService = ragService,
         _deferIndexWarmup = deferIndexWarmup,
+        _fingerprintLock = initialLock,
         _collectionServices = {
           SourceRagService.defaultCollectionId: ragService
         },
         _initializedCollections = {SourceRagService.defaultCollectionId},
         _collectionInitInFlight = {};
+
+  /// Snapshot of the active embedding fingerprint lock (null when unlocked).
+  ///
+  /// Search and ingest entry points throw
+  /// `RagError.embeddingFingerprintMismatch` while this is non-null. Use
+  /// [reembedAll] to recover without losing data or [clearAndRestart] to
+  /// discard embeddings after explicit confirmation.
+  RagEmbeddingFingerprintLock? get embeddingFingerprintLock => _fingerprintLock;
+
+  /// Whether boot detected an embedding fingerprint mismatch.
+  bool get isEmbeddingFingerprintLocked => _fingerprintLock != null;
+
+  void _ensureEmbeddingFingerprintUnlocked() {
+    final lock = _fingerprintLock;
+    if (lock != null) {
+      throw RagError.embeddingFingerprintMismatch(
+        lock.stored,
+        lock.current,
+        lock.remainingChunks,
+      );
+    }
+  }
 
   String _normalizeCollectionId(String? collectionId) {
     final trimmed = collectionId?.trim();
@@ -325,13 +382,70 @@ class RagEngine {
     );
     await ragService.init(deferIndexWarmup: config.deferIndexWarmup);
 
+    // 6. Resolve the embedding fingerprint gate. The probe is a single
+    //    one-shot embed used purely to read the model's output dimension;
+    //    the result is discarded. Must happen AFTER migration_meta exists
+    //    (created by ragService.init via init_source_db).
+    onProgress?.call('Validating embedding fingerprint...');
+    final probe = await EmbeddingService.embed(_kFingerprintProbeText);
+    final currentFingerprint = computeEmbeddingFingerprint(
+      modelBasename: embeddingModelBasename(modelPath),
+      dim: probe.length,
+      quant: kDefaultEmbeddingQuant,
+    );
+    final initialLock = await _resolveFingerprintGate(currentFingerprint);
+    if (initialLock != null) {
+      debugPrint(
+        '[RagEngine] Embedding fingerprint mismatch detected: '
+        'stored="${initialLock.stored}", current="$currentFingerprint", '
+        'remaining=${initialLock.remainingChunks}, '
+        'resume=${initialLock.resumeInProgress}. '
+        'Search/ingest will be locked until reembedAll() or clearAndRestart().',
+      );
+    }
+
     onProgress?.call('Ready!');
     return RagEngine._(
       ragService: ragService,
       dbPath: dbPath,
       vocabSize: vocabSize,
+      currentEmbeddingFingerprint: currentFingerprint,
+      initialLock: initialLock,
       deferIndexWarmup: config.deferIndexWarmup,
     );
+  }
+
+  /// One-shot probe text used solely to read the model's output dimension.
+  /// The embedding is thrown away; only `length` matters.
+  static const String _kFingerprintProbeText = '__mobile_rag_engine_probe__';
+
+  static Future<RagEmbeddingFingerprintLock?> _resolveFingerprintGate(
+    String currentFingerprint,
+  ) async {
+    final gate = await migration_meta.detectEmbeddingFingerprintGate(
+      currentFingerprint: currentFingerprint,
+    );
+    switch (gate) {
+      case migration_meta.EmbeddingFingerprintGate_RequiresInitialBaseline():
+        await migration_meta.writeEmbeddingFingerprint(
+          fingerprint: currentFingerprint,
+        );
+        return null;
+      case migration_meta.EmbeddingFingerprintGate_Ok():
+        return null;
+      case migration_meta.EmbeddingFingerprintGate_Mismatch(
+          stored: final stored,
+          current: final current,
+          remainingChunks: final remaining,
+          resumeInProgress: final resume,
+        ):
+        return RagEmbeddingFingerprintLock(
+          stored: stored,
+          current: current,
+          remainingChunks: remaining,
+          resumeInProgress: resume,
+        );
+    }
   }
 
   /// Copy asset file to filesystem if it doesn't exist.
@@ -357,14 +471,16 @@ class RagEngine {
     return path;
   }
 
-  /// Read-only snapshot of the four on-device data migration axes.
+  /// Read-only snapshot of all on-device data migration axes.
   ///
   /// Reflects the `migration_meta` row written by `init_source_db`:
   /// `sql_schema_version`, `hnsw_format_version`, `bm25_stats_version`,
-  /// `embedding_fingerprint`, plus the last engine version recorded at boot.
-  /// Phase P0-2 will populate `embedding_fingerprint`; later phases gate
-  /// behavior on the integer axes.
-  Future<MigrationAxes> get migrationState => readMigrationAxes();
+  /// `embedding_fingerprint`, `embedding_fingerprint_pending`, plus the last
+  /// engine version recorded at boot. Later phases gate behavior on the
+  /// integer axes; the fingerprint axes feed the P0-2 mismatch gate exposed
+  /// via [embeddingFingerprintLock].
+  Future<migration_meta.MigrationAxes> get migrationState =>
+      migration_meta.readMigrationAxes();
 
   /// Whether all retrieval indexes are ready for full-quality search.
   bool get isIndexReady => _ragService.isIndexReady;
@@ -409,6 +525,7 @@ class RagEngine {
     void Function(int done, int total)? onProgress,
     String? collectionId,
   }) async {
+    _ensureEmbeddingFingerprintUnlocked();
     final normalized = _normalizeCollectionId(collectionId);
     final service = await _serviceForCollection(normalized);
 
@@ -443,6 +560,7 @@ class RagEngine {
     void Function(int done, int total)? onProgress,
     String? collectionId,
   }) async {
+    _ensureEmbeddingFingerprintUnlocked();
     final normalized = _normalizeCollectionId(collectionId);
     final service = await _serviceForCollection(normalized);
 
@@ -475,6 +593,7 @@ class RagEngine {
     void Function(int done, int total)? onProgress,
     String? collectionId,
   }) async {
+    _ensureEmbeddingFingerprintUnlocked();
     final normalized = _normalizeCollectionId(collectionId);
     final service = await _serviceForCollection(normalized);
 
@@ -515,6 +634,7 @@ class RagEngine {
     List<int>? sourceIds,
     String? collectionId,
   }) async {
+    _ensureEmbeddingFingerprintUnlocked();
     final service = await _serviceForCollection(collectionId);
     await _flushIndex(
       collectionId: collectionId,
@@ -540,6 +660,7 @@ class RagEngine {
     int adjacentChunks = 0,
     String? collectionId,
   }) async {
+    _ensureEmbeddingFingerprintUnlocked();
     final service = await _serviceForCollection(collectionId);
     await _flushIndex(collectionId: collectionId);
     return service.searchMeta(
@@ -627,6 +748,7 @@ class RagEngine {
     List<int>? sourceIds,
     String? collectionId,
   }) async {
+    _ensureEmbeddingFingerprintUnlocked();
     final service = await _serviceForCollection(collectionId);
     await _flushIndex(
       collectionId: collectionId,
@@ -662,6 +784,7 @@ class RagEngine {
     int previewMaxBytes = 512,
     String? collectionId,
   }) async {
+    _ensureEmbeddingFingerprintUnlocked();
     final service = await _serviceForCollection(collectionId);
     await _flushIndex(
       collectionId: collectionId,
@@ -687,6 +810,7 @@ class RagEngine {
   /// performance. The index enables fast approximate nearest neighbor search.
   /// [force] - If true, rebuilds even if no changes were detected (default: false).
   Future<void> rebuildIndex({bool force = false, String? collectionId}) async {
+    _ensureEmbeddingFingerprintUnlocked();
     final normalized = _normalizeCollectionId(collectionId);
     final service = await _serviceForCollection(normalized);
 
@@ -777,6 +901,124 @@ class RagEngine {
   /// Format search results as an LLM prompt.
   String formatPrompt(String query, RagSearchResult result) =>
       _ragService.formatPrompt(query, result);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Embedding fingerprint recovery (P0-2)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /// Resolve an [embeddingFingerprintLock] by re-embedding every chunk with
+  /// the currently loaded model.
+  ///
+  /// The flow is **resumable**: progress is persisted per chunk on the Rust
+  /// side, so killing the app mid-stream and restarting will let a subsequent
+  /// `reembedAll()` pick up where this one left off without re-doing finished
+  /// chunks. `onProgress` is invoked once per chunk with the cumulative
+  /// (done, total) snapshot for the current run.
+  ///
+  /// On success the lock is cleared and the HNSW index is rebuilt with the
+  /// new embeddings. Throws [StateError] if no mismatch is active.
+  ///
+  /// Cold-start latency budget for this call is "background, minutes-scale"
+  /// — host apps SHOULD surface progress UI.
+  Future<void> reembedAll({
+    void Function(RagReembedProgress progress)? onProgress,
+    int batchSize = 32,
+  }) async {
+    final lock = _fingerprintLock;
+    if (lock == null) {
+      throw StateError(
+        'reembedAll() called but no embedding fingerprint mismatch is active.',
+      );
+    }
+    if (batchSize <= 0) {
+      throw ArgumentError.value(batchSize, 'batchSize', 'must be positive');
+    }
+    final target = currentEmbeddingFingerprint;
+    final initialRemaining = await migration_meta.beginEmbeddingReembed(
+      targetFingerprint: target,
+    );
+    final total = initialRemaining;
+    var done = 0;
+    onProgress?.call(RagReembedProgress(done: done, total: total));
+
+    while (true) {
+      final batch = await rust_rag.listChunksNeedingReembed(
+        targetFingerprint: target,
+        limit: batchSize,
+      );
+      if (batch.isEmpty) break;
+      for (final chunk in batch) {
+        final embedding = await EmbeddingService.embed(chunk.content);
+        await rust_rag.updateChunkReembedded(
+          chunkId: chunk.chunkId,
+          embedding: embedding,
+          targetFingerprint: target,
+        );
+        done += 1;
+        onProgress?.call(RagReembedProgress(done: done, total: total));
+        // Yield so the embed loop never starves the event queue (e.g. so
+        // host-app UI updates can land between chunks).
+        await Future<void>.delayed(Duration.zero);
+      }
+    }
+
+    await migration_meta.finalizeEmbeddingReembed(targetFingerprint: target);
+    _fingerprintLock = null;
+    debugPrint(
+      '[RagEngine] reembedAll: completed $done/$total chunks; '
+      'fingerprint now "$target". Rebuilding HNSW index...',
+    );
+    // The chunk embeddings just got rotated; force a rebuild so vector search
+    // is consistent with the new fingerprint before we hand control back.
+    await _ragService.rebuildIndex(force: true);
+  }
+
+  /// Resolve an [embeddingFingerprintLock] by discarding every on-device
+  /// embedding (chunks table) and rotating the fingerprint baseline.
+  ///
+  /// `confirm` MUST be
+  /// [ClearAndRestartConfirmation.iUnderstandThisDeletesAllOnDeviceEmbeddings];
+  /// the parameter exists solely to make the destructive choice visible at
+  /// every call site. The `sources` table is preserved so the host app can
+  /// re-ingest the original documents through the normal `addDocument` flow.
+  ///
+  /// Throws [StateError] if no mismatch is active.
+  Future<void> clearAndRestart({
+    required ClearAndRestartConfirmation confirm,
+  }) async {
+    // Reference the parameter so static analysis confirms the caller passed
+    // an explicit value (typing out the sentinel name is the consent).
+    identical(
+      confirm,
+      ClearAndRestartConfirmation.iUnderstandThisDeletesAllOnDeviceEmbeddings,
+    );
+    if (_fingerprintLock == null) {
+      throw StateError(
+        'clearAndRestart() called but no embedding fingerprint mismatch is active.',
+      );
+    }
+    final target = currentEmbeddingFingerprint;
+    final deleted = await migration_meta.acknowledgeAndClearEmbeddings(
+      confirmation: kEmbeddingClearConfirmationToken,
+      newFingerprint: target,
+    );
+    _fingerprintLock = null;
+    debugPrint(
+      '[RagEngine] clearAndRestart: deleted $deleted chunks; '
+      'fingerprint reset to "$target". Rebuilding empty HNSW index...',
+    );
+    await _ragService.rebuildIndex(force: true);
+  }
+
+  /// Up-to-date count of chunks still tagged with a non-current fingerprint.
+  ///
+  /// Safe to call while reembed is running — uses a read-only SELECT.
+  Future<int> reembedRemaining() async {
+    final count = await migration_meta.countChunksNeedingReembed(
+      targetFingerprint: currentEmbeddingFingerprint,
+    );
+    return count;
+  }
 
   /// Regenerate embeddings for all existing chunks.
   ///

--- a/lib/services/source_rag_service.dart
+++ b/lib/services/source_rag_service.dart
@@ -39,6 +39,8 @@ extension RagErrorMessage on RagError {
         internalError: (msg) => msg,
         unsupportedMigrationVersion: (axis, stored, supported) =>
             "Unsupported migration axis '$axis': stored=$stored, supported=$supported",
+        embeddingFingerprintMismatch: (stored, current, remaining) =>
+            "Embedding fingerprint mismatch: stored='$stored', current='$current', remaining=$remaining",
         unknown: (msg) => msg,
       );
 }
@@ -812,6 +814,10 @@ class SourceRagService {
             '[SmartError] Unsupported migration axis $axis '
             '(stored=$stored, supported=$supported) while rebuilding indexes',
           ),
+          embeddingFingerprintMismatch: (stored, current, remaining) => debugPrint(
+            '[SmartError] Rebuild blocked by fingerprint mismatch '
+            '(stored=$stored, current=$current, remaining=$remaining)',
+          ),
           unknown: (_) {},
         );
         rethrow;
@@ -978,6 +984,10 @@ class SourceRagService {
           '[SmartError] searchMeta blocked by unsupported migration axis '
           '$axis (stored=$stored, supported=$supported)',
         ),
+        embeddingFingerprintMismatch: (stored, current, remaining) => debugPrint(
+          '[SmartError] searchMeta blocked by fingerprint mismatch '
+          '(stored=$stored, current=$current, remaining=$remaining)',
+        ),
         unknown: (msg) => debugPrint('[SmartError] searchMeta unknown: $msg'),
       );
       rethrow;
@@ -1106,6 +1116,10 @@ class SourceRagService {
         unsupportedMigrationVersion: (axis, stored, supported) => debugPrint(
           '[SmartError] Search blocked by unsupported migration axis '
           '$axis (stored=$stored, supported=$supported)',
+        ),
+        embeddingFingerprintMismatch: (stored, current, remaining) => debugPrint(
+          '[SmartError] Search blocked by fingerprint mismatch '
+          '(stored=$stored, current=$current, remaining=$remaining)',
         ),
         unknown: (msg) => debugPrint('[SmartError] Unknown search error: $msg'),
       );
@@ -1481,6 +1495,10 @@ class SourceRagService {
           '[SmartError] Hybrid search blocked by unsupported migration axis '
           '$axis (stored=$stored, supported=$supported)',
         ),
+        embeddingFingerprintMismatch: (stored, current, remaining) => log(
+          '[SmartError] Hybrid search blocked by fingerprint mismatch '
+          '(stored=$stored, current=$current, remaining=$remaining)',
+        ),
         unknown: (msg) => log('[SmartError] Hybrid search unknown error: $msg'),
       );
       rethrow;
@@ -1540,6 +1558,7 @@ class SourceRagService {
           concurrentMutation: (_) => true,
           internalError: (_) => false,
           unsupportedMigrationVersion: (_, __, ___) => false,
+          embeddingFingerprintMismatch: (_, __, ___) => false,
           unknown: (_) => false,
         );
         if (!isRetryable || attempt == 1) {

--- a/lib/src/internal/embedding_fingerprint.dart
+++ b/lib/src/internal/embedding_fingerprint.dart
@@ -1,0 +1,136 @@
+/// Helpers for computing and validating the on-device embedding fingerprint.
+///
+/// The fingerprint identifies which `(model, dim, quant)` combination
+/// produced the embeddings persisted on disk. It is opaque to consumers and
+/// only compared as a single string against the value the engine binary
+/// produces on each boot.
+library;
+
+/// Wire format produced by [computeEmbeddingFingerprint].
+///
+/// `{modelBasename}|{dim}|{quant}`
+///
+/// Example: `my-model.onnx|384|f32`.
+///
+/// The basename is taken from `modelPath` rather than its bytes so a host
+/// app that replaces the file in-place forces a mismatch (same path, new
+/// bytes ⇒ same basename ⇒ same fingerprint is not what we want; in that
+/// situation the host MUST also rename the file to a new basename). We rely
+/// on the dim component to catch the most common case of swapping models
+/// with different output sizes, even if the basename is reused.
+String computeEmbeddingFingerprint({
+  required String modelBasename,
+  required int dim,
+  required String quant,
+}) {
+  if (modelBasename.isEmpty) {
+    throw ArgumentError.value(
+      modelBasename,
+      'modelBasename',
+      'must be non-empty',
+    );
+  }
+  if (dim <= 0) {
+    throw ArgumentError.value(dim, 'dim', 'must be positive');
+  }
+  if (quant.isEmpty) {
+    throw ArgumentError.value(quant, 'quant', 'must be non-empty');
+  }
+  return '$modelBasename|$dim|$quant';
+}
+
+/// Extract just the file name component from `modelPath`.
+///
+/// Tolerates both `/` and `\` separators so the fingerprint stays stable
+/// across the platforms mobile_rag_engine ships on.
+String embeddingModelBasename(String modelPath) {
+  if (modelPath.isEmpty) return modelPath;
+  final lastSlash = modelPath.lastIndexOf('/');
+  final lastBackslash = modelPath.lastIndexOf('\\');
+  final cut = lastSlash > lastBackslash ? lastSlash : lastBackslash;
+  return cut >= 0 ? modelPath.substring(cut + 1) : modelPath;
+}
+
+/// Default quantization tag emitted by the engine binary's default build.
+///
+/// Phase P2-5 may want to plumb the actual build flag (`vector_quant_i8`)
+/// through here; for P0-2 every build serves `f32` embeddings on the search
+/// hot path, so a single constant is honest and stable.
+const String kDefaultEmbeddingQuant = 'f32';
+
+/// Must exactly match `EMBEDDING_CLEAR_CONFIRMATION` in
+/// `rust_builder/rust/src/api/migration_meta.rs`. Duplicated here because the
+/// Rust `pub const &str` is not surfaced through flutter_rust_bridge bindings.
+const String kEmbeddingClearConfirmationToken =
+    'I_UNDERSTAND_THIS_DELETES_ALL_ON_DEVICE_EMBEDDINGS';
+
+/// Snapshot of an active embedding fingerprint mismatch.
+///
+/// While `MobileRag.instance.embeddingFingerprintLock` is non-null, every
+/// search and ingest API throws `RagError.embeddingFingerprintMismatch`.
+/// Resolve by calling `reembedAll(progress:)` (preserves data) or
+/// `clearAndRestart(confirm:)` (discards embeddings after explicit consent).
+class RagEmbeddingFingerprintLock {
+  /// Fingerprint persisted on disk when the lock was opened.
+  final String stored;
+
+  /// Fingerprint produced by the currently loaded embedding model.
+  final String current;
+
+  /// Number of chunks still tagged with a non-current fingerprint at the
+  /// moment the lock was opened. Use `MobileRag.instance.reembedRemaining()`
+  /// for an up-to-date count during a long-running reembed.
+  final int remainingChunks;
+
+  /// True when a previous reembed-to-`current` attempt left
+  /// `embedding_fingerprint_pending` set, so the new run can pick up where
+  /// the previous one left off without a fresh user prompt.
+  final bool resumeInProgress;
+
+  const RagEmbeddingFingerprintLock({
+    required this.stored,
+    required this.current,
+    required this.remainingChunks,
+    required this.resumeInProgress,
+  });
+
+  @override
+  String toString() =>
+      'RagEmbeddingFingerprintLock(stored: $stored, current: $current, '
+      'remaining: $remainingChunks, resume: $resumeInProgress)';
+}
+
+/// Typed acknowledgment that the caller understands `clearAndRestart` deletes
+/// every on-device embedding BLOB. Required as an explicit parameter so the
+/// destructive choice is visible at every call site.
+class ClearAndRestartConfirmation {
+  const ClearAndRestartConfirmation._();
+
+  /// Sentinel value the caller must pass to opt into deletion.
+  ///
+  /// The name is verbose by design — typing it out is the consent.
+  static const ClearAndRestartConfirmation
+      iUnderstandThisDeletesAllOnDeviceEmbeddings =
+      ClearAndRestartConfirmation._();
+}
+
+/// Progress event emitted during `reembedAll(progress:)`.
+class RagReembedProgress {
+  /// Chunks successfully re-embedded in the current run.
+  final int done;
+
+  /// Snapshot of the total work captured when the run began. May be slightly
+  /// lower than `done` if new chunks were ingested mid-run on a prior boot
+  /// before the engine became locked.
+  final int total;
+
+  const RagReembedProgress({required this.done, required this.total});
+
+  /// Fraction in `[0, 1]`. Clamped to 1 when `total == 0` so UI bindings
+  /// don't blow up on an empty corpus.
+  double get fraction =>
+      total == 0 ? 1.0 : (done / total).clamp(0.0, 1.0).toDouble();
+
+  @override
+  String toString() => 'RagReembedProgress($done/$total)';
+}

--- a/lib/src/rust/api/error.dart
+++ b/lib/src/rust/api/error.dart
@@ -47,6 +47,16 @@ sealed class RagError with _$RagError implements FrbException {
     PlatformInt64 field2,
   ) = RagError_UnsupportedMigrationVersion;
 
+  /// The currently loaded embedding model produced a fingerprint that does
+  /// not match the one persisted on disk. Search and ingest must remain
+  /// locked until the host app explicitly drives either reembed-all or
+  /// clear-and-restart. Field order: (stored, current, remaining_chunks).
+  const factory RagError.embeddingFingerprintMismatch(
+    String field0,
+    String field1,
+    PlatformInt64 field2,
+  ) = RagError_EmbeddingFingerprintMismatch;
+
   /// Unknown error.
   const factory RagError.unknown(String field0) = RagError_Unknown;
 }

--- a/lib/src/rust/api/error.freezed.dart
+++ b/lib/src/rust/api/error.freezed.dart
@@ -86,7 +86,7 @@ extension RagErrorPatterns on RagError {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( RagError_DatabaseError value)?  databaseError,TResult Function( RagError_IoError value)?  ioError,TResult Function( RagError_ModelLoadError value)?  modelLoadError,TResult Function( RagError_InvalidInput value)?  invalidInput,TResult Function( RagError_StaleSearchHandle value)?  staleSearchHandle,TResult Function( RagError_ConcurrentMutation value)?  concurrentMutation,TResult Function( RagError_InternalError value)?  internalError,TResult Function( RagError_UnsupportedMigrationVersion value)?  unsupportedMigrationVersion,TResult Function( RagError_Unknown value)?  unknown,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( RagError_DatabaseError value)?  databaseError,TResult Function( RagError_IoError value)?  ioError,TResult Function( RagError_ModelLoadError value)?  modelLoadError,TResult Function( RagError_InvalidInput value)?  invalidInput,TResult Function( RagError_StaleSearchHandle value)?  staleSearchHandle,TResult Function( RagError_ConcurrentMutation value)?  concurrentMutation,TResult Function( RagError_InternalError value)?  internalError,TResult Function( RagError_UnsupportedMigrationVersion value)?  unsupportedMigrationVersion,TResult Function( RagError_EmbeddingFingerprintMismatch value)?  embeddingFingerprintMismatch,TResult Function( RagError_Unknown value)?  unknown,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case RagError_DatabaseError() when databaseError != null:
@@ -97,7 +97,8 @@ return invalidInput(_that);case RagError_StaleSearchHandle() when staleSearchHan
 return staleSearchHandle(_that);case RagError_ConcurrentMutation() when concurrentMutation != null:
 return concurrentMutation(_that);case RagError_InternalError() when internalError != null:
 return internalError(_that);case RagError_UnsupportedMigrationVersion() when unsupportedMigrationVersion != null:
-return unsupportedMigrationVersion(_that);case RagError_Unknown() when unknown != null:
+return unsupportedMigrationVersion(_that);case RagError_EmbeddingFingerprintMismatch() when embeddingFingerprintMismatch != null:
+return embeddingFingerprintMismatch(_that);case RagError_Unknown() when unknown != null:
 return unknown(_that);case _:
   return orElse();
 
@@ -116,7 +117,7 @@ return unknown(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( RagError_DatabaseError value)  databaseError,required TResult Function( RagError_IoError value)  ioError,required TResult Function( RagError_ModelLoadError value)  modelLoadError,required TResult Function( RagError_InvalidInput value)  invalidInput,required TResult Function( RagError_StaleSearchHandle value)  staleSearchHandle,required TResult Function( RagError_ConcurrentMutation value)  concurrentMutation,required TResult Function( RagError_InternalError value)  internalError,required TResult Function( RagError_UnsupportedMigrationVersion value)  unsupportedMigrationVersion,required TResult Function( RagError_Unknown value)  unknown,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( RagError_DatabaseError value)  databaseError,required TResult Function( RagError_IoError value)  ioError,required TResult Function( RagError_ModelLoadError value)  modelLoadError,required TResult Function( RagError_InvalidInput value)  invalidInput,required TResult Function( RagError_StaleSearchHandle value)  staleSearchHandle,required TResult Function( RagError_ConcurrentMutation value)  concurrentMutation,required TResult Function( RagError_InternalError value)  internalError,required TResult Function( RagError_UnsupportedMigrationVersion value)  unsupportedMigrationVersion,required TResult Function( RagError_EmbeddingFingerprintMismatch value)  embeddingFingerprintMismatch,required TResult Function( RagError_Unknown value)  unknown,}){
 final _that = this;
 switch (_that) {
 case RagError_DatabaseError():
@@ -127,7 +128,8 @@ return invalidInput(_that);case RagError_StaleSearchHandle():
 return staleSearchHandle(_that);case RagError_ConcurrentMutation():
 return concurrentMutation(_that);case RagError_InternalError():
 return internalError(_that);case RagError_UnsupportedMigrationVersion():
-return unsupportedMigrationVersion(_that);case RagError_Unknown():
+return unsupportedMigrationVersion(_that);case RagError_EmbeddingFingerprintMismatch():
+return embeddingFingerprintMismatch(_that);case RagError_Unknown():
 return unknown(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
@@ -142,7 +144,7 @@ return unknown(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( RagError_DatabaseError value)?  databaseError,TResult? Function( RagError_IoError value)?  ioError,TResult? Function( RagError_ModelLoadError value)?  modelLoadError,TResult? Function( RagError_InvalidInput value)?  invalidInput,TResult? Function( RagError_StaleSearchHandle value)?  staleSearchHandle,TResult? Function( RagError_ConcurrentMutation value)?  concurrentMutation,TResult? Function( RagError_InternalError value)?  internalError,TResult? Function( RagError_UnsupportedMigrationVersion value)?  unsupportedMigrationVersion,TResult? Function( RagError_Unknown value)?  unknown,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( RagError_DatabaseError value)?  databaseError,TResult? Function( RagError_IoError value)?  ioError,TResult? Function( RagError_ModelLoadError value)?  modelLoadError,TResult? Function( RagError_InvalidInput value)?  invalidInput,TResult? Function( RagError_StaleSearchHandle value)?  staleSearchHandle,TResult? Function( RagError_ConcurrentMutation value)?  concurrentMutation,TResult? Function( RagError_InternalError value)?  internalError,TResult? Function( RagError_UnsupportedMigrationVersion value)?  unsupportedMigrationVersion,TResult? Function( RagError_EmbeddingFingerprintMismatch value)?  embeddingFingerprintMismatch,TResult? Function( RagError_Unknown value)?  unknown,}){
 final _that = this;
 switch (_that) {
 case RagError_DatabaseError() when databaseError != null:
@@ -153,7 +155,8 @@ return invalidInput(_that);case RagError_StaleSearchHandle() when staleSearchHan
 return staleSearchHandle(_that);case RagError_ConcurrentMutation() when concurrentMutation != null:
 return concurrentMutation(_that);case RagError_InternalError() when internalError != null:
 return internalError(_that);case RagError_UnsupportedMigrationVersion() when unsupportedMigrationVersion != null:
-return unsupportedMigrationVersion(_that);case RagError_Unknown() when unknown != null:
+return unsupportedMigrationVersion(_that);case RagError_EmbeddingFingerprintMismatch() when embeddingFingerprintMismatch != null:
+return embeddingFingerprintMismatch(_that);case RagError_Unknown() when unknown != null:
 return unknown(_that);case _:
   return null;
 
@@ -171,7 +174,7 @@ return unknown(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String field0)?  databaseError,TResult Function( String field0)?  ioError,TResult Function( String field0)?  modelLoadError,TResult Function( String field0)?  invalidInput,TResult Function( String field0)?  staleSearchHandle,TResult Function( String field0)?  concurrentMutation,TResult Function( String field0)?  internalError,TResult Function( String field0,  PlatformInt64 field1,  PlatformInt64 field2)?  unsupportedMigrationVersion,TResult Function( String field0)?  unknown,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String field0)?  databaseError,TResult Function( String field0)?  ioError,TResult Function( String field0)?  modelLoadError,TResult Function( String field0)?  invalidInput,TResult Function( String field0)?  staleSearchHandle,TResult Function( String field0)?  concurrentMutation,TResult Function( String field0)?  internalError,TResult Function( String field0,  PlatformInt64 field1,  PlatformInt64 field2)?  unsupportedMigrationVersion,TResult Function( String field0,  String field1,  PlatformInt64 field2)?  embeddingFingerprintMismatch,TResult Function( String field0)?  unknown,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case RagError_DatabaseError() when databaseError != null:
 return databaseError(_that.field0);case RagError_IoError() when ioError != null:
@@ -181,7 +184,8 @@ return invalidInput(_that.field0);case RagError_StaleSearchHandle() when staleSe
 return staleSearchHandle(_that.field0);case RagError_ConcurrentMutation() when concurrentMutation != null:
 return concurrentMutation(_that.field0);case RagError_InternalError() when internalError != null:
 return internalError(_that.field0);case RagError_UnsupportedMigrationVersion() when unsupportedMigrationVersion != null:
-return unsupportedMigrationVersion(_that.field0,_that.field1,_that.field2);case RagError_Unknown() when unknown != null:
+return unsupportedMigrationVersion(_that.field0,_that.field1,_that.field2);case RagError_EmbeddingFingerprintMismatch() when embeddingFingerprintMismatch != null:
+return embeddingFingerprintMismatch(_that.field0,_that.field1,_that.field2);case RagError_Unknown() when unknown != null:
 return unknown(_that.field0);case _:
   return orElse();
 
@@ -200,7 +204,7 @@ return unknown(_that.field0);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String field0)  databaseError,required TResult Function( String field0)  ioError,required TResult Function( String field0)  modelLoadError,required TResult Function( String field0)  invalidInput,required TResult Function( String field0)  staleSearchHandle,required TResult Function( String field0)  concurrentMutation,required TResult Function( String field0)  internalError,required TResult Function( String field0,  PlatformInt64 field1,  PlatformInt64 field2)  unsupportedMigrationVersion,required TResult Function( String field0)  unknown,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String field0)  databaseError,required TResult Function( String field0)  ioError,required TResult Function( String field0)  modelLoadError,required TResult Function( String field0)  invalidInput,required TResult Function( String field0)  staleSearchHandle,required TResult Function( String field0)  concurrentMutation,required TResult Function( String field0)  internalError,required TResult Function( String field0,  PlatformInt64 field1,  PlatformInt64 field2)  unsupportedMigrationVersion,required TResult Function( String field0,  String field1,  PlatformInt64 field2)  embeddingFingerprintMismatch,required TResult Function( String field0)  unknown,}) {final _that = this;
 switch (_that) {
 case RagError_DatabaseError():
 return databaseError(_that.field0);case RagError_IoError():
@@ -210,7 +214,8 @@ return invalidInput(_that.field0);case RagError_StaleSearchHandle():
 return staleSearchHandle(_that.field0);case RagError_ConcurrentMutation():
 return concurrentMutation(_that.field0);case RagError_InternalError():
 return internalError(_that.field0);case RagError_UnsupportedMigrationVersion():
-return unsupportedMigrationVersion(_that.field0,_that.field1,_that.field2);case RagError_Unknown():
+return unsupportedMigrationVersion(_that.field0,_that.field1,_that.field2);case RagError_EmbeddingFingerprintMismatch():
+return embeddingFingerprintMismatch(_that.field0,_that.field1,_that.field2);case RagError_Unknown():
 return unknown(_that.field0);}
 }
 /// A variant of `when` that fallback to returning `null`
@@ -225,7 +230,7 @@ return unknown(_that.field0);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String field0)?  databaseError,TResult? Function( String field0)?  ioError,TResult? Function( String field0)?  modelLoadError,TResult? Function( String field0)?  invalidInput,TResult? Function( String field0)?  staleSearchHandle,TResult? Function( String field0)?  concurrentMutation,TResult? Function( String field0)?  internalError,TResult? Function( String field0,  PlatformInt64 field1,  PlatformInt64 field2)?  unsupportedMigrationVersion,TResult? Function( String field0)?  unknown,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String field0)?  databaseError,TResult? Function( String field0)?  ioError,TResult? Function( String field0)?  modelLoadError,TResult? Function( String field0)?  invalidInput,TResult? Function( String field0)?  staleSearchHandle,TResult? Function( String field0)?  concurrentMutation,TResult? Function( String field0)?  internalError,TResult? Function( String field0,  PlatformInt64 field1,  PlatformInt64 field2)?  unsupportedMigrationVersion,TResult? Function( String field0,  String field1,  PlatformInt64 field2)?  embeddingFingerprintMismatch,TResult? Function( String field0)?  unknown,}) {final _that = this;
 switch (_that) {
 case RagError_DatabaseError() when databaseError != null:
 return databaseError(_that.field0);case RagError_IoError() when ioError != null:
@@ -235,7 +240,8 @@ return invalidInput(_that.field0);case RagError_StaleSearchHandle() when staleSe
 return staleSearchHandle(_that.field0);case RagError_ConcurrentMutation() when concurrentMutation != null:
 return concurrentMutation(_that.field0);case RagError_InternalError() when internalError != null:
 return internalError(_that.field0);case RagError_UnsupportedMigrationVersion() when unsupportedMigrationVersion != null:
-return unsupportedMigrationVersion(_that.field0,_that.field1,_that.field2);case RagError_Unknown() when unknown != null:
+return unsupportedMigrationVersion(_that.field0,_that.field1,_that.field2);case RagError_EmbeddingFingerprintMismatch() when embeddingFingerprintMismatch != null:
+return embeddingFingerprintMismatch(_that.field0,_that.field1,_that.field2);case RagError_Unknown() when unknown != null:
 return unknown(_that.field0);case _:
   return null;
 
@@ -769,6 +775,76 @@ class _$RagError_UnsupportedMigrationVersionCopyWithImpl<$Res>
 null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
 as String,null == field1 ? _self.field1 : field1 // ignore: cast_nullable_to_non_nullable
 as PlatformInt64,null == field2 ? _self.field2 : field2 // ignore: cast_nullable_to_non_nullable
+as PlatformInt64,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class RagError_EmbeddingFingerprintMismatch extends RagError {
+  const RagError_EmbeddingFingerprintMismatch(this.field0, this.field1, this.field2): super._();
+  
+
+@override final  String field0;
+ final  String field1;
+ final  PlatformInt64 field2;
+
+/// Create a copy of RagError
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RagError_EmbeddingFingerprintMismatchCopyWith<RagError_EmbeddingFingerprintMismatch> get copyWith => _$RagError_EmbeddingFingerprintMismatchCopyWithImpl<RagError_EmbeddingFingerprintMismatch>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RagError_EmbeddingFingerprintMismatch&&(identical(other.field0, field0) || other.field0 == field0)&&(identical(other.field1, field1) || other.field1 == field1)&&(identical(other.field2, field2) || other.field2 == field2));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0,field1,field2);
+
+@override
+String toString() {
+  return 'RagError.embeddingFingerprintMismatch(field0: $field0, field1: $field1, field2: $field2)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RagError_EmbeddingFingerprintMismatchCopyWith<$Res> implements $RagErrorCopyWith<$Res> {
+  factory $RagError_EmbeddingFingerprintMismatchCopyWith(RagError_EmbeddingFingerprintMismatch value, $Res Function(RagError_EmbeddingFingerprintMismatch) _then) = _$RagError_EmbeddingFingerprintMismatchCopyWithImpl;
+@override @useResult
+$Res call({
+ String field0, String field1, PlatformInt64 field2
+});
+
+
+
+
+}
+/// @nodoc
+class _$RagError_EmbeddingFingerprintMismatchCopyWithImpl<$Res>
+    implements $RagError_EmbeddingFingerprintMismatchCopyWith<$Res> {
+  _$RagError_EmbeddingFingerprintMismatchCopyWithImpl(this._self, this._then);
+
+  final RagError_EmbeddingFingerprintMismatch _self;
+  final $Res Function(RagError_EmbeddingFingerprintMismatch) _then;
+
+/// Create a copy of RagError
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? field0 = null,Object? field1 = null,Object? field2 = null,}) {
+  return _then(RagError_EmbeddingFingerprintMismatch(
+null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as String,null == field1 ? _self.field1 : field1 // ignore: cast_nullable_to_non_nullable
+as String,null == field2 ? _self.field2 : field2 // ignore: cast_nullable_to_non_nullable
 as PlatformInt64,
   ));
 }

--- a/lib/src/rust/api/migration_meta.dart
+++ b/lib/src/rust/api/migration_meta.dart
@@ -6,9 +6,11 @@
 import '../frb_generated.dart';
 import 'error.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
+import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
+part 'migration_meta.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `assert_no_unknown_future_axes`, `bootstrap_axes`, `create_migration_meta_table`, `detect_existing_install`, `initialize_migration_meta`, `read_axes_with`, `read_axis_int`, `read_axis_string`, `upsert_axis`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `clone`, `eq`, `fmt`
+// These functions are ignored because they are not marked as `pub`: `assert_no_unknown_future_axes`, `bootstrap_axes`, `count_chunks_with_non_matching_fingerprint`, `create_migration_meta_table`, `detect_existing_install`, `initialize_migration_meta`, `insert_axis_if_absent`, `read_axes_with`, `read_axis_int`, `read_axis_string_or_empty`, `read_axis_string`, `upsert_axis`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`
 
 /// Read the current 4-axis state from `migration_meta`.
 ///
@@ -17,14 +19,126 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 Future<MigrationAxes> readMigrationAxes() =>
     RustLib.instance.api.crateApiMigrationMetaReadMigrationAxes();
 
-/// Read-only snapshot of the four versioning axes plus the last engine version.
+/// Inspect `migration_meta` against the currently loaded model fingerprint.
+///
+/// This call only **reads** state — it never mutates `embedding_fingerprint`
+/// nor deletes embeddings. The caller is responsible for routing the gate
+/// state to the user (Apply, Rebuild, Invalidate decisions per the data
+/// migration plan).
+Future<EmbeddingFingerprintGate> detectEmbeddingFingerprintGate({
+  required String currentFingerprint,
+}) => RustLib.instance.api.crateApiMigrationMetaDetectEmbeddingFingerprintGate(
+  currentFingerprint: currentFingerprint,
+);
+
+/// Record the engine's current model fingerprint as the persisted baseline.
+///
+/// Only callable when no baseline is present yet — i.e. when the previous
+/// [`detect_embedding_fingerprint_gate`] returned
+/// [`EmbeddingFingerprintGate::RequiresInitialBaseline`]. After this call,
+/// every existing chunk is tagged as belonging to `fingerprint` so future
+/// mismatches can compute `remaining_chunks` accurately.
+///
+/// Refuses to overwrite a non-empty baseline. Use the reembed/clear flows
+/// to rotate an existing fingerprint instead.
+Future<void> writeEmbeddingFingerprint({required String fingerprint}) => RustLib
+    .instance
+    .api
+    .crateApiMigrationMetaWriteEmbeddingFingerprint(fingerprint: fingerprint);
+
+/// Begin a reembed-to-`target_fingerprint` flow.
+///
+/// Writes `embedding_fingerprint_pending = target_fingerprint` (sticky across
+/// reboots, so the flow is resumable) and returns the number of chunks that
+/// still need re-embedding. Idempotent — calling it again with the same
+/// target is safe.
+Future<PlatformInt64> beginEmbeddingReembed({
+  required String targetFingerprint,
+}) => RustLib.instance.api.crateApiMigrationMetaBeginEmbeddingReembed(
+  targetFingerprint: targetFingerprint,
+);
+
+/// Count chunks still tagged with anything other than `target_fingerprint`.
+///
+/// Reads only — safe to call during progress polling.
+Future<PlatformInt64> countChunksNeedingReembed({
+  required String targetFingerprint,
+}) => RustLib.instance.api.crateApiMigrationMetaCountChunksNeedingReembed(
+  targetFingerprint: targetFingerprint,
+);
+
+/// Commit a completed reembed atomically.
+///
+/// Refuses to commit when any chunk still carries a non-matching fingerprint,
+/// guarding against accidentally promoting `embedding_fingerprint` past a
+/// partially completed run. On success: `embedding_fingerprint = target`,
+/// `embedding_fingerprint_pending = ""`.
+Future<void> finalizeEmbeddingReembed({required String targetFingerprint}) =>
+    RustLib.instance.api.crateApiMigrationMetaFinalizeEmbeddingReembed(
+      targetFingerprint: targetFingerprint,
+    );
+
+/// Discard every chunk row (and therefore every embedding BLOB) for sources
+/// the user has accepted as lost, then reset the fingerprint axes.
+///
+/// Refuses to do anything unless `confirmation` exactly equals
+/// [`EMBEDDING_CLEAR_CONFIRMATION`]. This is the only public path that may
+/// drop user embeddings; it must never be reachable from passive flows.
+///
+/// The `sources` rows are kept so the user can re-ingest them through the
+/// normal ingestion path; only `chunks` (which hold the embeddings) are
+/// removed.
+Future<PlatformInt64> acknowledgeAndClearEmbeddings({
+  required String confirmation,
+  required String newFingerprint,
+}) => RustLib.instance.api.crateApiMigrationMetaAcknowledgeAndClearEmbeddings(
+  confirmation: confirmation,
+  newFingerprint: newFingerprint,
+);
+
+@freezed
+sealed class EmbeddingFingerprintGate with _$EmbeddingFingerprintGate {
+  const EmbeddingFingerprintGate._();
+
+  /// No fingerprint persisted yet; caller should write the current one
+  /// before serving any requests. First-ever boot.
+  const factory EmbeddingFingerprintGate.requiresInitialBaseline() =
+      EmbeddingFingerprintGate_RequiresInitialBaseline;
+
+  /// Stored fingerprint matches `current_fingerprint`; safe to proceed.
+  const factory EmbeddingFingerprintGate.ok() = EmbeddingFingerprintGate_Ok;
+
+  /// Stored fingerprint differs from `current_fingerprint`; reads and
+  /// writes MUST be locked until either reembed completes or the user
+  /// explicitly confirms a clear-and-restart.
+  const factory EmbeddingFingerprintGate.mismatch({
+    required String stored,
+    required String current,
+
+    /// Number of chunk rows still tagged with a non-current fingerprint.
+    /// Useful for surfacing a "resume from N%" UI without an extra
+    /// round-trip to count chunks.
+    required PlatformInt64 remainingChunks,
+
+    /// True when `embedding_fingerprint_pending` already equals
+    /// `current_fingerprint` — i.e. a reembed was previously started and
+    /// can simply continue without a fresh user confirmation.
+    required bool resumeInProgress,
+  }) = EmbeddingFingerprintGate_Mismatch;
+}
+
+/// Read-only snapshot of all migration axes plus the last engine version.
 class MigrationAxes {
   final PlatformInt64 sqlSchemaVersion;
   final PlatformInt64 hnswFormatVersion;
   final PlatformInt64 bm25StatsVersion;
 
-  /// Empty string means "not yet registered" (P0-2 will populate).
+  /// Empty string means "not yet registered" — the boot probe will populate
+  /// it on the first model load via [`write_embedding_fingerprint`].
   final String embeddingFingerprint;
+
+  /// Non-empty while a reembed-to-`<value>` is in flight; empty otherwise.
+  final String embeddingFingerprintPending;
   final String lastEngineVersion;
 
   const MigrationAxes({
@@ -32,6 +146,7 @@ class MigrationAxes {
     required this.hnswFormatVersion,
     required this.bm25StatsVersion,
     required this.embeddingFingerprint,
+    required this.embeddingFingerprintPending,
     required this.lastEngineVersion,
   });
 
@@ -41,6 +156,7 @@ class MigrationAxes {
       hnswFormatVersion.hashCode ^
       bm25StatsVersion.hashCode ^
       embeddingFingerprint.hashCode ^
+      embeddingFingerprintPending.hashCode ^
       lastEngineVersion.hashCode;
 
   @override
@@ -52,5 +168,6 @@ class MigrationAxes {
           hnswFormatVersion == other.hnswFormatVersion &&
           bm25StatsVersion == other.bm25StatsVersion &&
           embeddingFingerprint == other.embeddingFingerprint &&
+          embeddingFingerprintPending == other.embeddingFingerprintPending &&
           lastEngineVersion == other.lastEngineVersion;
 }

--- a/lib/src/rust/api/migration_meta.freezed.dart
+++ b/lib/src/rust/api/migration_meta.freezed.dart
@@ -1,0 +1,322 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'migration_meta.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$EmbeddingFingerprintGate {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddingFingerprintGate);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'EmbeddingFingerprintGate()';
+}
+
+
+}
+
+/// @nodoc
+class $EmbeddingFingerprintGateCopyWith<$Res>  {
+$EmbeddingFingerprintGateCopyWith(EmbeddingFingerprintGate _, $Res Function(EmbeddingFingerprintGate) __);
+}
+
+
+/// Adds pattern-matching-related methods to [EmbeddingFingerprintGate].
+extension EmbeddingFingerprintGatePatterns on EmbeddingFingerprintGate {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( EmbeddingFingerprintGate_RequiresInitialBaseline value)?  requiresInitialBaseline,TResult Function( EmbeddingFingerprintGate_Ok value)?  ok,TResult Function( EmbeddingFingerprintGate_Mismatch value)?  mismatch,required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case EmbeddingFingerprintGate_RequiresInitialBaseline() when requiresInitialBaseline != null:
+return requiresInitialBaseline(_that);case EmbeddingFingerprintGate_Ok() when ok != null:
+return ok(_that);case EmbeddingFingerprintGate_Mismatch() when mismatch != null:
+return mismatch(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( EmbeddingFingerprintGate_RequiresInitialBaseline value)  requiresInitialBaseline,required TResult Function( EmbeddingFingerprintGate_Ok value)  ok,required TResult Function( EmbeddingFingerprintGate_Mismatch value)  mismatch,}){
+final _that = this;
+switch (_that) {
+case EmbeddingFingerprintGate_RequiresInitialBaseline():
+return requiresInitialBaseline(_that);case EmbeddingFingerprintGate_Ok():
+return ok(_that);case EmbeddingFingerprintGate_Mismatch():
+return mismatch(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( EmbeddingFingerprintGate_RequiresInitialBaseline value)?  requiresInitialBaseline,TResult? Function( EmbeddingFingerprintGate_Ok value)?  ok,TResult? Function( EmbeddingFingerprintGate_Mismatch value)?  mismatch,}){
+final _that = this;
+switch (_that) {
+case EmbeddingFingerprintGate_RequiresInitialBaseline() when requiresInitialBaseline != null:
+return requiresInitialBaseline(_that);case EmbeddingFingerprintGate_Ok() when ok != null:
+return ok(_that);case EmbeddingFingerprintGate_Mismatch() when mismatch != null:
+return mismatch(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  requiresInitialBaseline,TResult Function()?  ok,TResult Function( String stored,  String current,  PlatformInt64 remainingChunks,  bool resumeInProgress)?  mismatch,required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case EmbeddingFingerprintGate_RequiresInitialBaseline() when requiresInitialBaseline != null:
+return requiresInitialBaseline();case EmbeddingFingerprintGate_Ok() when ok != null:
+return ok();case EmbeddingFingerprintGate_Mismatch() when mismatch != null:
+return mismatch(_that.stored,_that.current,_that.remainingChunks,_that.resumeInProgress);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  requiresInitialBaseline,required TResult Function()  ok,required TResult Function( String stored,  String current,  PlatformInt64 remainingChunks,  bool resumeInProgress)  mismatch,}) {final _that = this;
+switch (_that) {
+case EmbeddingFingerprintGate_RequiresInitialBaseline():
+return requiresInitialBaseline();case EmbeddingFingerprintGate_Ok():
+return ok();case EmbeddingFingerprintGate_Mismatch():
+return mismatch(_that.stored,_that.current,_that.remainingChunks,_that.resumeInProgress);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  requiresInitialBaseline,TResult? Function()?  ok,TResult? Function( String stored,  String current,  PlatformInt64 remainingChunks,  bool resumeInProgress)?  mismatch,}) {final _that = this;
+switch (_that) {
+case EmbeddingFingerprintGate_RequiresInitialBaseline() when requiresInitialBaseline != null:
+return requiresInitialBaseline();case EmbeddingFingerprintGate_Ok() when ok != null:
+return ok();case EmbeddingFingerprintGate_Mismatch() when mismatch != null:
+return mismatch(_that.stored,_that.current,_that.remainingChunks,_that.resumeInProgress);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class EmbeddingFingerprintGate_RequiresInitialBaseline extends EmbeddingFingerprintGate {
+  const EmbeddingFingerprintGate_RequiresInitialBaseline(): super._();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddingFingerprintGate_RequiresInitialBaseline);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'EmbeddingFingerprintGate.requiresInitialBaseline()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class EmbeddingFingerprintGate_Ok extends EmbeddingFingerprintGate {
+  const EmbeddingFingerprintGate_Ok(): super._();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddingFingerprintGate_Ok);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'EmbeddingFingerprintGate.ok()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class EmbeddingFingerprintGate_Mismatch extends EmbeddingFingerprintGate {
+  const EmbeddingFingerprintGate_Mismatch({required this.stored, required this.current, required this.remainingChunks, required this.resumeInProgress}): super._();
+  
+
+ final  String stored;
+ final  String current;
+/// Number of chunk rows still tagged with a non-current fingerprint.
+/// Useful for surfacing a "resume from N%" UI without an extra
+/// round-trip to count chunks.
+ final  PlatformInt64 remainingChunks;
+/// True when `embedding_fingerprint_pending` already equals
+/// `current_fingerprint` — i.e. a reembed was previously started and
+/// can simply continue without a fresh user confirmation.
+ final  bool resumeInProgress;
+
+/// Create a copy of EmbeddingFingerprintGate
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EmbeddingFingerprintGate_MismatchCopyWith<EmbeddingFingerprintGate_Mismatch> get copyWith => _$EmbeddingFingerprintGate_MismatchCopyWithImpl<EmbeddingFingerprintGate_Mismatch>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EmbeddingFingerprintGate_Mismatch&&(identical(other.stored, stored) || other.stored == stored)&&(identical(other.current, current) || other.current == current)&&(identical(other.remainingChunks, remainingChunks) || other.remainingChunks == remainingChunks)&&(identical(other.resumeInProgress, resumeInProgress) || other.resumeInProgress == resumeInProgress));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,stored,current,remainingChunks,resumeInProgress);
+
+@override
+String toString() {
+  return 'EmbeddingFingerprintGate.mismatch(stored: $stored, current: $current, remainingChunks: $remainingChunks, resumeInProgress: $resumeInProgress)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EmbeddingFingerprintGate_MismatchCopyWith<$Res> implements $EmbeddingFingerprintGateCopyWith<$Res> {
+  factory $EmbeddingFingerprintGate_MismatchCopyWith(EmbeddingFingerprintGate_Mismatch value, $Res Function(EmbeddingFingerprintGate_Mismatch) _then) = _$EmbeddingFingerprintGate_MismatchCopyWithImpl;
+@useResult
+$Res call({
+ String stored, String current, PlatformInt64 remainingChunks, bool resumeInProgress
+});
+
+
+
+
+}
+/// @nodoc
+class _$EmbeddingFingerprintGate_MismatchCopyWithImpl<$Res>
+    implements $EmbeddingFingerprintGate_MismatchCopyWith<$Res> {
+  _$EmbeddingFingerprintGate_MismatchCopyWithImpl(this._self, this._then);
+
+  final EmbeddingFingerprintGate_Mismatch _self;
+  final $Res Function(EmbeddingFingerprintGate_Mismatch) _then;
+
+/// Create a copy of EmbeddingFingerprintGate
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? stored = null,Object? current = null,Object? remainingChunks = null,Object? resumeInProgress = null,}) {
+  return _then(EmbeddingFingerprintGate_Mismatch(
+stored: null == stored ? _self.stored : stored // ignore: cast_nullable_to_non_nullable
+as String,current: null == current ? _self.current : current // ignore: cast_nullable_to_non_nullable
+as String,remainingChunks: null == remainingChunks ? _self.remainingChunks : remainingChunks // ignore: cast_nullable_to_non_nullable
+as PlatformInt64,resumeInProgress: null == resumeInProgress ? _self.resumeInProgress : resumeInProgress // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/src/rust/api/source_rag.dart
+++ b/lib/src/rust/api/source_rag.dart
@@ -273,6 +273,35 @@ Future<void> updateChunkEmbedding({
   embedding: embedding,
 );
 
+/// Stream the next batch of chunks that still carry a non-matching fingerprint.
+///
+/// Used by the reembed flow to walk the corpus incrementally without holding
+/// the entire chunk set in Dart memory. The batch is ordered by `id` so a
+/// caller that crashes between batches can resume deterministically.
+Future<List<ChunkForReembedding>> listChunksNeedingReembed({
+  required String targetFingerprint,
+  required PlatformInt64 limit,
+}) => RustLib.instance.api.crateApiSourceRagListChunksNeedingReembed(
+  targetFingerprint: targetFingerprint,
+  limit: limit,
+);
+
+/// Atomically replace a chunk's embedding and tag it with `target_fingerprint`.
+///
+/// Single-statement UPDATE so a crash mid-write cannot leave a chunk with the
+/// new embedding bytes but the old fingerprint marker (or vice versa). Marks
+/// the chunk's collection as dirty so the next HNSW rebuild picks up the new
+/// vector.
+Future<void> updateChunkReembedded({
+  required PlatformInt64 chunkId,
+  required List<double> embedding,
+  required String targetFingerprint,
+}) => RustLib.instance.api.crateApiSourceRagUpdateChunkReembedded(
+  chunkId: chunkId,
+  embedding: embedding,
+  targetFingerprint: targetFingerprint,
+);
+
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<SearchHandle>>
 abstract class SearchHandle implements RustOpaqueInterface {
   Future<AssembledContextV2> assembleContext({

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -84,7 +84,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1936558543;
+  int get rustContentHash => 907237406;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -163,6 +163,11 @@ abstract class RustLibApi extends BaseApi {
     required Int64List chunkIds,
   });
 
+  Future<PlatformInt64> crateApiMigrationMetaAcknowledgeAndClearEmbeddings({
+    required String confirmation,
+    required String newFingerprint,
+  });
+
   Future<void> crateApiSourceRagActivateCollectionForHybridSearch({
     required String collectionId,
     required String basePath,
@@ -194,6 +199,10 @@ abstract class RustLibApi extends BaseApi {
     required String content,
     String? metadata,
     String? name,
+  });
+
+  Future<PlatformInt64> crateApiMigrationMetaBeginEmbeddingReembed({
+    required String targetFingerprint,
   });
 
   Future<List<ChunkSearchResult>>
@@ -279,6 +288,10 @@ abstract class RustLibApi extends BaseApi {
   Future<CompressionOptions>
   crateApiCompressionUtilsCompressionOptionsDefault();
 
+  Future<PlatformInt64> crateApiMigrationMetaCountChunksNeedingReembed({
+    required String targetFingerprint,
+  });
+
   int crateApiTokenizerCountTokens({required String text});
 
   String crateApiTokenizerDecodeTokens({required List<int> tokenIds});
@@ -297,6 +310,11 @@ abstract class RustLibApi extends BaseApi {
     required bool useStrictMode,
     required int safetyMarginTokens,
     int? fixedPromptOverheadTokens,
+  });
+
+  Future<EmbeddingFingerprintGate>
+  crateApiMigrationMetaDetectEmbeddingFingerprintGate({
+    required String currentFingerprint,
   });
 
   Future<EmbeddingPoint> crateApiHnswIndexEmbeddingPointNew({
@@ -322,6 +340,10 @@ abstract class RustLibApi extends BaseApi {
 
   Future<String> crateApiDocumentParserExtractTextFromUtf8({
     required List<int> fileBytes,
+  });
+
+  Future<void> crateApiMigrationMetaFinalizeEmbeddingReembed({
+    required String targetFingerprint,
   });
 
   Future<List<ChunkSearchResult>> crateApiSourceRagGetAdjacentChunks({
@@ -425,6 +447,11 @@ abstract class RustLibApi extends BaseApi {
   Future<bool> crateApiHnswIndexIsHnswIndexLoaded();
 
   Future<bool> crateApiDbPoolIsPoolInitialized();
+
+  Future<List<ChunkForReembedding>> crateApiSourceRagListChunksNeedingReembed({
+    required String targetFingerprint,
+    required PlatformInt64 limit,
+  });
 
   Future<List<SourceEntry>> crateApiSourceRagListSources();
 
@@ -620,6 +647,12 @@ abstract class RustLibApi extends BaseApi {
     required List<double> embedding,
   });
 
+  Future<void> crateApiSourceRagUpdateChunkReembedded({
+    required PlatformInt64 chunkId,
+    required List<double> embedding,
+    required String targetFingerprint,
+  });
+
   Future<void> crateApiSourceRagUpdateSourceStatus({
     required PlatformInt64 sourceId,
     required String status,
@@ -629,6 +662,10 @@ abstract class RustLibApi extends BaseApi {
 
   Future<void> crateApiUserIntentUserIntentIntentType({
     required UserIntent that,
+  });
+
+  Future<void> crateApiMigrationMetaWriteEmbeddingFingerprint({
+    required String fingerprint,
   });
 
   RustArcIncrementStrongCountFnType
@@ -1212,6 +1249,42 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<PlatformInt64> crateApiMigrationMetaAcknowledgeAndClearEmbeddings({
+    required String confirmation,
+    required String newFingerprint,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(confirmation, serializer);
+          sse_encode_String(newFingerprint, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 16,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_i_64,
+          decodeErrorData: sse_decode_rag_error,
+        ),
+        constMeta: kCrateApiMigrationMetaAcknowledgeAndClearEmbeddingsConstMeta,
+        argValues: [confirmation, newFingerprint],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiMigrationMetaAcknowledgeAndClearEmbeddingsConstMeta =>
+      const TaskConstMeta(
+        debugName: "acknowledge_and_clear_embeddings",
+        argNames: ["confirmation", "newFingerprint"],
+      );
+
+  @override
   Future<void> crateApiSourceRagActivateCollectionForHybridSearch({
     required String collectionId,
     required String basePath,
@@ -1225,7 +1298,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 17,
             port: port_,
           );
         },
@@ -1261,7 +1334,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 18,
             port: port_,
           );
         },
@@ -1295,7 +1368,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 19,
             port: port_,
           );
         },
@@ -1330,7 +1403,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 20,
             port: port_,
           );
         },
@@ -1367,7 +1440,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 21,
             port: port_,
           );
         },
@@ -1405,7 +1478,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 22,
             port: port_,
           );
         },
@@ -1427,6 +1500,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<PlatformInt64> crateApiMigrationMetaBeginEmbeddingReembed({
+    required String targetFingerprint,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(targetFingerprint, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 23,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_i_64,
+          decodeErrorData: sse_decode_rag_error,
+        ),
+        constMeta: kCrateApiMigrationMetaBeginEmbeddingReembedConstMeta,
+        argValues: [targetFingerprint],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiMigrationMetaBeginEmbeddingReembedConstMeta =>
+      const TaskConstMeta(
+        debugName: "begin_embedding_reembed",
+        argNames: ["targetFingerprint"],
+      );
+
+  @override
   Future<List<ChunkSearchResult>>
   crateApiSourceRagBenchmarkSearchChunksLinearInCollection({
     required String collectionId,
@@ -1443,7 +1549,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 24,
             port: port_,
           );
         },
@@ -1480,7 +1586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 25,
             port: port_,
           );
         },
@@ -1515,7 +1621,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 26,
             port: port_,
           );
         },
@@ -1548,7 +1654,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1575,7 +1681,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 28,
             port: port_,
           );
         },
@@ -1602,7 +1708,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1632,7 +1738,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1667,7 +1773,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 31,
             port: port_,
           );
         },
@@ -1700,7 +1806,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1729,7 +1835,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_prim_f_32_loose(vecA, serializer);
           sse_encode_list_prim_f_32_loose(vecB, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_f_64,
@@ -1760,7 +1866,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 34,
             port: port_,
           );
         },
@@ -1790,7 +1896,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1820,7 +1926,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1848,7 +1954,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(text, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_chunk_type,
@@ -1873,7 +1979,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 38,
             port: port_,
           );
         },
@@ -1900,7 +2006,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 39,
             port: port_,
           );
         },
@@ -1927,7 +2033,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 40,
             port: port_,
           );
         },
@@ -1957,7 +2063,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1987,7 +2093,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 42,
             port: port_,
           );
         },
@@ -2011,7 +2117,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2043,7 +2149,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 44,
             port: port_,
           );
         },
@@ -2078,7 +2184,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 45,
             port: port_,
           );
         },
@@ -2109,7 +2215,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 46,
             port: port_,
           );
         },
@@ -2132,13 +2238,46 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<PlatformInt64> crateApiMigrationMetaCountChunksNeedingReembed({
+    required String targetFingerprint,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(targetFingerprint, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 47,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_i_64,
+          decodeErrorData: sse_decode_rag_error,
+        ),
+        constMeta: kCrateApiMigrationMetaCountChunksNeedingReembedConstMeta,
+        argValues: [targetFingerprint],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiMigrationMetaCountChunksNeedingReembedConstMeta =>
+      const TaskConstMeta(
+        debugName: "count_chunks_needing_reembed",
+        argNames: ["targetFingerprint"],
+      );
+
+  @override
   int crateApiTokenizerCountTokens({required String text}) {
     return handler.executeSync(
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(text, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_32,
@@ -2161,7 +2300,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_prim_u_32_loose(tokenIds, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2189,7 +2328,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 50,
             port: port_,
           );
         },
@@ -2221,7 +2360,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 51,
             port: port_,
           );
         },
@@ -2267,7 +2406,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 52,
             port: port_,
           );
         },
@@ -2303,6 +2442,42 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<EmbeddingFingerprintGate>
+  crateApiMigrationMetaDetectEmbeddingFingerprintGate({
+    required String currentFingerprint,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(currentFingerprint, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 53,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_embedding_fingerprint_gate,
+          decodeErrorData: sse_decode_rag_error,
+        ),
+        constMeta:
+            kCrateApiMigrationMetaDetectEmbeddingFingerprintGateConstMeta,
+        argValues: [currentFingerprint],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiMigrationMetaDetectEmbeddingFingerprintGateConstMeta =>
+      const TaskConstMeta(
+        debugName: "detect_embedding_fingerprint_gate",
+        argNames: ["currentFingerprint"],
+      );
+
+  @override
   Future<EmbeddingPoint> crateApiHnswIndexEmbeddingPointNew({
     required PlatformInt64 id,
     required List<double> embedding,
@@ -2316,7 +2491,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 54,
             port: port_,
           );
         },
@@ -2349,7 +2524,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 55,
             port: port_,
           );
         },
@@ -2382,7 +2557,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 56,
             port: port_,
           );
         },
@@ -2415,7 +2590,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 57,
             port: port_,
           );
         },
@@ -2448,7 +2623,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 58,
             port: port_,
           );
         },
@@ -2481,7 +2656,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 59,
             port: port_,
           );
         },
@@ -2503,6 +2678,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<void> crateApiMigrationMetaFinalizeEmbeddingReembed({
+    required String targetFingerprint,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(targetFingerprint, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 60,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_rag_error,
+        ),
+        constMeta: kCrateApiMigrationMetaFinalizeEmbeddingReembedConstMeta,
+        argValues: [targetFingerprint],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiMigrationMetaFinalizeEmbeddingReembedConstMeta =>
+      const TaskConstMeta(
+        debugName: "finalize_embedding_reembed",
+        argNames: ["targetFingerprint"],
+      );
+
+  @override
   Future<List<ChunkSearchResult>> crateApiSourceRagGetAdjacentChunks({
     required PlatformInt64 sourceId,
     required int minIndex,
@@ -2518,7 +2726,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 61,
             port: port_,
           );
         },
@@ -2549,7 +2757,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 62,
             port: port_,
           );
         },
@@ -2583,7 +2791,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 63,
             port: port_,
           );
         },
@@ -2616,7 +2824,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 64,
             port: port_,
           );
         },
@@ -2643,7 +2851,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 65,
             port: port_,
           );
         },
@@ -2670,7 +2878,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 66,
             port: port_,
           );
         },
@@ -2697,7 +2905,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 67,
             port: port_,
           );
         },
@@ -2727,7 +2935,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 68,
             port: port_,
           );
         },
@@ -2757,7 +2965,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 69,
             port: port_,
           );
         },
@@ -2790,7 +2998,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 65,
+            funcId: 70,
             port: port_,
           );
         },
@@ -2820,7 +3028,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 71,
             port: port_,
           );
         },
@@ -2850,7 +3058,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 67,
+            funcId: 72,
             port: port_,
           );
         },
@@ -2883,7 +3091,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 68,
+            funcId: 73,
             port: port_,
           );
         },
@@ -2910,7 +3118,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_32,
@@ -2933,7 +3141,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 75)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2963,7 +3171,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 71,
+            funcId: 76,
             port: port_,
           );
         },
@@ -2996,7 +3204,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 72,
+            funcId: 77,
             port: port_,
           );
         },
@@ -3029,7 +3237,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 73,
+            funcId: 78,
             port: port_,
           );
         },
@@ -3062,7 +3270,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 74,
+            funcId: 79,
             port: port_,
           );
         },
@@ -3089,7 +3297,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 75)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_ingest_traffic_stats,
@@ -3117,7 +3325,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 81,
             port: port_,
           );
         },
@@ -3153,7 +3361,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 82,
             port: port_,
           );
         },
@@ -3185,7 +3393,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 83,
             port: port_,
           );
         },
@@ -3212,7 +3420,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 84,
             port: port_,
           );
         },
@@ -3244,7 +3452,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 85,
             port: port_,
           );
         },
@@ -3272,7 +3480,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_StreamSink_String_Sse(sink, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 81)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3298,7 +3506,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 82,
+            funcId: 87,
             port: port_,
           );
         },
@@ -3325,7 +3533,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 88,
             port: port_,
           );
         },
@@ -3353,7 +3561,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 89,
             port: port_,
           );
         },
@@ -3383,7 +3591,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 90,
             port: port_,
           );
         },
@@ -3410,7 +3618,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 86,
+            funcId: 91,
             port: port_,
           );
         },
@@ -3440,7 +3648,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 92,
             port: port_,
           );
         },
@@ -3467,7 +3675,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 93,
             port: port_,
           );
         },
@@ -3486,6 +3694,41 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "is_pool_initialized", argNames: []);
 
   @override
+  Future<List<ChunkForReembedding>> crateApiSourceRagListChunksNeedingReembed({
+    required String targetFingerprint,
+    required PlatformInt64 limit,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(targetFingerprint, serializer);
+          sse_encode_i_64(limit, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 94,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_chunk_for_reembedding,
+          decodeErrorData: sse_decode_rag_error,
+        ),
+        constMeta: kCrateApiSourceRagListChunksNeedingReembedConstMeta,
+        argValues: [targetFingerprint, limit],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSourceRagListChunksNeedingReembedConstMeta =>
+      const TaskConstMeta(
+        debugName: "list_chunks_needing_reembed",
+        argNames: ["targetFingerprint", "limit"],
+      );
+
+  @override
   Future<List<SourceEntry>> crateApiSourceRagListSources() {
     return handler.executeNormal(
       NormalTask(
@@ -3494,7 +3737,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 95,
             port: port_,
           );
         },
@@ -3524,7 +3767,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 96,
             port: port_,
           );
         },
@@ -3559,7 +3802,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 97,
             port: port_,
           );
         },
@@ -3590,7 +3833,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 98,
             port: port_,
           );
         },
@@ -3619,7 +3862,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(text, serializer);
           sse_encode_i_32(maxChars, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_structured_chunk,
@@ -3647,7 +3890,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 100,
             port: port_,
           );
         },
@@ -3672,7 +3915,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(input, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 95)!;
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 101,
+          )!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_parsed_intent,
@@ -3695,7 +3942,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(input, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 96)!;
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 102,
+          )!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_user_intent,
@@ -3735,7 +3986,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 103,
             port: port_,
           );
         },
@@ -3797,7 +4048,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 104,
             port: port_,
           );
         },
@@ -3861,7 +4112,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 105,
             port: port_,
           );
         },
@@ -3909,7 +4160,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 106,
           )!;
         },
         codec: SseCodec(
@@ -3938,7 +4189,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 107,
             port: port_,
           );
         },
@@ -3974,7 +4225,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 108,
             port: port_,
           );
         },
@@ -4009,7 +4260,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 109,
             port: port_,
           );
         },
@@ -4044,7 +4295,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 110,
             port: port_,
           );
         },
@@ -4075,7 +4326,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 111,
             port: port_,
           );
         },
@@ -4102,7 +4353,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 112,
             port: port_,
           );
         },
@@ -4129,7 +4380,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 113,
             port: port_,
           );
         },
@@ -4159,7 +4410,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 114,
             port: port_,
           );
         },
@@ -4191,7 +4442,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 115,
             port: port_,
           );
         },
@@ -4221,7 +4472,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 116,
             port: port_,
           );
         },
@@ -4253,7 +4504,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 117,
             port: port_,
           );
         },
@@ -4280,7 +4531,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 118,
           )!;
         },
         codec: SseCodec(
@@ -4309,7 +4560,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 119,
           )!;
         },
         codec: SseCodec(
@@ -4338,7 +4589,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 120,
             port: port_,
           );
         },
@@ -4370,7 +4621,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 121,
             port: port_,
           );
         },
@@ -4401,7 +4652,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 122,
             port: port_,
           );
         },
@@ -4433,7 +4684,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 123,
             port: port_,
           );
         },
@@ -4470,7 +4721,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 124,
             port: port_,
           );
         },
@@ -4505,7 +4756,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 125,
             port: port_,
           );
         },
@@ -4540,7 +4791,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 126,
             port: port_,
           );
         },
@@ -4581,7 +4832,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 127,
             port: port_,
           );
         },
@@ -4618,7 +4869,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 128,
             port: port_,
           );
         },
@@ -4659,7 +4910,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 129,
             port: port_,
           );
         },
@@ -4707,7 +4958,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 124,
+            funcId: 130,
             port: port_,
           );
         },
@@ -4743,7 +4994,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 125,
+            funcId: 131,
             port: port_,
           );
         },
@@ -4778,7 +5029,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 126,
+            funcId: 132,
           )!;
         },
         codec: SseCodec(
@@ -4814,7 +5065,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 127,
+            funcId: 133,
           )!;
         },
         codec: SseCodec(
@@ -4846,7 +5097,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 128,
+            funcId: 134,
             port: port_,
           );
         },
@@ -4878,7 +5129,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 129,
+            funcId: 135,
             port: port_,
           );
         },
@@ -4911,7 +5162,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 130,
+            funcId: 136,
             port: port_,
           );
         },
@@ -4938,7 +5189,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 131,
+            funcId: 137,
           )!;
         },
         codec: SseCodec(
@@ -4968,7 +5219,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 132,
+            funcId: 138,
           )!;
         },
         codec: SseCodec(
@@ -4999,7 +5250,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 133,
+            funcId: 139,
             port: port_,
           );
         },
@@ -5021,6 +5272,43 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<void> crateApiSourceRagUpdateChunkReembedded({
+    required PlatformInt64 chunkId,
+    required List<double> embedding,
+    required String targetFingerprint,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_i_64(chunkId, serializer);
+          sse_encode_list_prim_f_32_loose(embedding, serializer);
+          sse_encode_String(targetFingerprint, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 140,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_rag_error,
+        ),
+        constMeta: kCrateApiSourceRagUpdateChunkReembeddedConstMeta,
+        argValues: [chunkId, embedding, targetFingerprint],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSourceRagUpdateChunkReembeddedConstMeta =>
+      const TaskConstMeta(
+        debugName: "update_chunk_reembedded",
+        argNames: ["chunkId", "embedding", "targetFingerprint"],
+      );
+
+  @override
   Future<void> crateApiSourceRagUpdateSourceStatus({
     required PlatformInt64 sourceId,
     required String status,
@@ -5034,7 +5322,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 134,
+            funcId: 141,
             port: port_,
           );
         },
@@ -5067,7 +5355,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 135,
+            funcId: 142,
             port: port_,
           );
         },
@@ -5100,7 +5388,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 136,
+            funcId: 143,
             port: port_,
           );
         },
@@ -5119,6 +5407,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(
         debugName: "user_intent_intent_type",
         argNames: ["that"],
+      );
+
+  @override
+  Future<void> crateApiMigrationMetaWriteEmbeddingFingerprint({
+    required String fingerprint,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(fingerprint, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 144,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_rag_error,
+        ),
+        constMeta: kCrateApiMigrationMetaWriteEmbeddingFingerprintConstMeta,
+        argValues: [fingerprint],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiMigrationMetaWriteEmbeddingFingerprintConstMeta =>
+      const TaskConstMeta(
+        debugName: "write_embedding_fingerprint",
+        argNames: ["fingerprint"],
       );
 
   RustArcIncrementStrongCountFnType
@@ -5528,6 +5849,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  EmbeddingFingerprintGate dco_decode_embedding_fingerprint_gate(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    switch (raw[0]) {
+      case 0:
+        return EmbeddingFingerprintGate_RequiresInitialBaseline();
+      case 1:
+        return EmbeddingFingerprintGate_Ok();
+      case 2:
+        return EmbeddingFingerprintGate_Mismatch(
+          stored: dco_decode_String(raw[1]),
+          current: dco_decode_String(raw[2]),
+          remainingChunks: dco_decode_i_64(raw[3]),
+          resumeInProgress: dco_decode_bool(raw[4]),
+        );
+      default:
+        throw Exception("unreachable");
+    }
+  }
+
+  @protected
   EmbeddingPoint dco_decode_embedding_point(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
@@ -5808,14 +6149,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MigrationAxes dco_decode_migration_axes(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 5)
-      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    if (arr.length != 6)
+      throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return MigrationAxes(
       sqlSchemaVersion: dco_decode_i_64(arr[0]),
       hnswFormatVersion: dco_decode_i_64(arr[1]),
       bm25StatsVersion: dco_decode_i_64(arr[2]),
       embeddingFingerprint: dco_decode_String(arr[3]),
-      lastEngineVersion: dco_decode_String(arr[4]),
+      embeddingFingerprintPending: dco_decode_String(arr[4]),
+      lastEngineVersion: dco_decode_String(arr[5]),
     );
   }
 
@@ -5981,6 +6323,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dco_decode_i_64(raw[3]),
         );
       case 8:
+        return RagError_EmbeddingFingerprintMismatch(
+          dco_decode_String(raw[1]),
+          dco_decode_String(raw[2]),
+          dco_decode_i_64(raw[3]),
+        );
+      case 9:
         return RagError_Unknown(dco_decode_String(raw[1]));
       default:
         throw Exception("unreachable");
@@ -6651,6 +6999,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  EmbeddingFingerprintGate sse_decode_embedding_fingerprint_gate(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var tag_ = sse_decode_i_32(deserializer);
+    switch (tag_) {
+      case 0:
+        return EmbeddingFingerprintGate_RequiresInitialBaseline();
+      case 1:
+        return EmbeddingFingerprintGate_Ok();
+      case 2:
+        var var_stored = sse_decode_String(deserializer);
+        var var_current = sse_decode_String(deserializer);
+        var var_remainingChunks = sse_decode_i_64(deserializer);
+        var var_resumeInProgress = sse_decode_bool(deserializer);
+        return EmbeddingFingerprintGate_Mismatch(
+          stored: var_stored,
+          current: var_current,
+          remainingChunks: var_remainingChunks,
+          resumeInProgress: var_resumeInProgress,
+        );
+      default:
+        throw UnimplementedError('');
+    }
+  }
+
+  @protected
   EmbeddingPoint sse_decode_embedding_point(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_id = sse_decode_i_64(deserializer);
@@ -7075,12 +7451,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_hnswFormatVersion = sse_decode_i_64(deserializer);
     var var_bm25StatsVersion = sse_decode_i_64(deserializer);
     var var_embeddingFingerprint = sse_decode_String(deserializer);
+    var var_embeddingFingerprintPending = sse_decode_String(deserializer);
     var var_lastEngineVersion = sse_decode_String(deserializer);
     return MigrationAxes(
       sqlSchemaVersion: var_sqlSchemaVersion,
       hnswFormatVersion: var_hnswFormatVersion,
       bm25StatsVersion: var_bm25StatsVersion,
       embeddingFingerprint: var_embeddingFingerprint,
+      embeddingFingerprintPending: var_embeddingFingerprintPending,
       lastEngineVersion: var_lastEngineVersion,
     );
   }
@@ -7341,6 +7719,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           var_field2,
         );
       case 8:
+        var var_field0 = sse_decode_String(deserializer);
+        var var_field1 = sse_decode_String(deserializer);
+        var var_field2 = sse_decode_i_64(deserializer);
+        return RagError_EmbeddingFingerprintMismatch(
+          var_field0,
+          var_field1,
+          var_field2,
+        );
+      case 9:
         var var_field0 = sse_decode_String(deserializer);
         return RagError_Unknown(var_field0);
       default:
@@ -8009,6 +8396,31 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_embedding_fingerprint_gate(
+    EmbeddingFingerprintGate self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    switch (self) {
+      case EmbeddingFingerprintGate_RequiresInitialBaseline():
+        sse_encode_i_32(0, serializer);
+      case EmbeddingFingerprintGate_Ok():
+        sse_encode_i_32(1, serializer);
+      case EmbeddingFingerprintGate_Mismatch(
+        stored: final stored,
+        current: final current,
+        remainingChunks: final remainingChunks,
+        resumeInProgress: final resumeInProgress,
+      ):
+        sse_encode_i_32(2, serializer);
+        sse_encode_String(stored, serializer);
+        sse_encode_String(current, serializer);
+        sse_encode_i_64(remainingChunks, serializer);
+        sse_encode_bool(resumeInProgress, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_embedding_point(
     EmbeddingPoint self,
     SseSerializer serializer,
@@ -8405,6 +8817,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_i_64(self.hnswFormatVersion, serializer);
     sse_encode_i_64(self.bm25StatsVersion, serializer);
     sse_encode_String(self.embeddingFingerprint, serializer);
+    sse_encode_String(self.embeddingFingerprintPending, serializer);
     sse_encode_String(self.lastEngineVersion, serializer);
   }
 
@@ -8627,8 +9040,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(field0, serializer);
         sse_encode_i_64(field1, serializer);
         sse_encode_i_64(field2, serializer);
-      case RagError_Unknown(field0: final field0):
+      case RagError_EmbeddingFingerprintMismatch(
+        field0: final field0,
+        field1: final field1,
+        field2: final field2,
+      ):
         sse_encode_i_32(8, serializer);
+        sse_encode_String(field0, serializer);
+        sse_encode_String(field1, serializer);
+        sse_encode_i_64(field2, serializer);
+      case RagError_Unknown(field0: final field0):
+        sse_encode_i_32(9, serializer);
         sse_encode_String(field0, serializer);
     }
   }

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -201,6 +201,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ContextAssemblyStrategy dco_decode_context_assembly_strategy(dynamic raw);
 
   @protected
+  EmbeddingFingerprintGate dco_decode_embedding_fingerprint_gate(dynamic raw);
+
+  @protected
   EmbeddingPoint dco_decode_embedding_point(dynamic raw);
 
   @protected
@@ -595,6 +598,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ContextAssemblyStrategy sse_decode_context_assembly_strategy(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  EmbeddingFingerprintGate sse_decode_embedding_fingerprint_gate(
     SseDeserializer deserializer,
   );
 
@@ -1091,6 +1099,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_context_assembly_strategy(
     ContextAssemblyStrategy self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_embedding_fingerprint_gate(
+    EmbeddingFingerprintGate self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -203,6 +203,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ContextAssemblyStrategy dco_decode_context_assembly_strategy(dynamic raw);
 
   @protected
+  EmbeddingFingerprintGate dco_decode_embedding_fingerprint_gate(dynamic raw);
+
+  @protected
   EmbeddingPoint dco_decode_embedding_point(dynamic raw);
 
   @protected
@@ -597,6 +600,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ContextAssemblyStrategy sse_decode_context_assembly_strategy(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  EmbeddingFingerprintGate sse_decode_embedding_fingerprint_gate(
     SseDeserializer deserializer,
   );
 
@@ -1093,6 +1101,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_context_assembly_strategy(
     ContextAssemblyStrategy self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_embedding_fingerprint_gate(
+    EmbeddingFingerprintGate self,
     SseSerializer serializer,
   );
 

--- a/lib/utils/error_utils.dart
+++ b/lib/utils/error_utils.dart
@@ -19,6 +19,8 @@ extension RagErrorUi on RagError {
       internalError: (_) => 'A temporary internal error occurred.',
       unsupportedMigrationVersion: (axis, stored, supported) =>
           'On-device data was written by a newer version of the app ($axis=$stored, this build supports $supported). Please update the app to continue.',
+      embeddingFingerprintMismatch: (stored, current, remaining) =>
+          'The embedding model changed since this device last indexed your data. Tap "Re-embed" to keep your saved documents or "Reset" to start fresh.',
       unknown: (_) => 'An unknown error occurred.',
     );
   }
@@ -35,6 +37,8 @@ extension RagErrorUi on RagError {
       internalError: (msg) => msg,
       unsupportedMigrationVersion: (axis, stored, supported) =>
           'UnsupportedMigrationVersion(axis=$axis, stored=$stored, supported=$supported)',
+      embeddingFingerprintMismatch: (stored, current, remaining) =>
+          'EmbeddingFingerprintMismatch(stored=$stored, current=$current, remaining=$remaining)',
       unknown: (msg) => msg,
     );
   }

--- a/rust_builder/rust/src/api/error.rs
+++ b/rust_builder/rust/src/api/error.rs
@@ -39,6 +39,13 @@ pub enum RagError {
     #[error("Unsupported migration axis '{0}': stored version {1} is newer than build's supported version {2}. Downgrade is not supported.")]
     UnsupportedMigrationVersion(String, i64, i64),
 
+    /// The currently loaded embedding model produced a fingerprint that does
+    /// not match the one persisted on disk. Search and ingest must remain
+    /// locked until the host app explicitly drives either reembed-all or
+    /// clear-and-restart. Field order: (stored, current, remaining_chunks).
+    #[error("Embedding fingerprint mismatch: stored='{0}', current='{1}', remaining_chunks={2}. Call reembedAll() to reuse stored documents or clearAndRestart() to discard them.")]
+    EmbeddingFingerprintMismatch(String, String, i64),
+
     /// Unknown error.
     #[error("Unknown error: {0}")]
     Unknown(String),

--- a/rust_builder/rust/src/api/migration_meta.rs
+++ b/rust_builder/rust/src/api/migration_meta.rs
@@ -51,19 +51,25 @@ pub const KEY_SQL_SCHEMA_VERSION: &str = "sql_schema_version";
 pub const KEY_HNSW_FORMAT_VERSION: &str = "hnsw_format_version";
 pub const KEY_BM25_STATS_VERSION: &str = "bm25_stats_version";
 pub const KEY_EMBEDDING_FINGERPRINT: &str = "embedding_fingerprint";
+/// Set to the *target* fingerprint while a reembed is in flight; empty
+/// otherwise. Lets boot detect a resumable reembed after an interrupted run.
+pub const KEY_EMBEDDING_FINGERPRINT_PENDING: &str = "embedding_fingerprint_pending";
 pub const KEY_LAST_ENGINE_VERSION: &str = "last_engine_version";
 
 /// Sentinel value persisted before Phase P0-2 registers a real fingerprint.
-const EMPTY_FINGERPRINT: &str = "";
+pub const EMPTY_FINGERPRINT: &str = "";
 
-/// Read-only snapshot of the four versioning axes plus the last engine version.
+/// Read-only snapshot of all migration axes plus the last engine version.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MigrationAxes {
     pub sql_schema_version: i64,
     pub hnsw_format_version: i64,
     pub bm25_stats_version: i64,
-    /// Empty string means "not yet registered" (P0-2 will populate).
+    /// Empty string means "not yet registered" — the boot probe will populate
+    /// it on the first model load via [`write_embedding_fingerprint`].
     pub embedding_fingerprint: String,
+    /// Non-empty while a reembed-to-`<value>` is in flight; empty otherwise.
+    pub embedding_fingerprint_pending: String,
     pub last_engine_version: String,
 }
 
@@ -135,12 +141,31 @@ fn read_axis_string(conn: &Connection, key: &str) -> Result<String, RagError> {
     .map_err(|e| RagError::DatabaseError(format!("migration_meta read '{key}': {e}")))
 }
 
+fn read_axis_string_or_empty(conn: &Connection, key: &str) -> Result<String, RagError> {
+    use rusqlite::OptionalExtension;
+    let value: Option<String> = conn
+        .query_row(
+            "SELECT value FROM migration_meta WHERE key = ?1",
+            params![key],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|e| RagError::DatabaseError(format!("migration_meta read '{key}': {e}")))?;
+    Ok(value.unwrap_or_default())
+}
+
 pub(crate) fn read_axes_with(conn: &Connection) -> Result<MigrationAxes, RagError> {
     Ok(MigrationAxes {
         sql_schema_version: read_axis_int(conn, KEY_SQL_SCHEMA_VERSION)?,
         hnsw_format_version: read_axis_int(conn, KEY_HNSW_FORMAT_VERSION)?,
         bm25_stats_version: read_axis_int(conn, KEY_BM25_STATS_VERSION)?,
         embedding_fingerprint: read_axis_string(conn, KEY_EMBEDDING_FINGERPRINT)?,
+        // Pending axis may be missing on installs that booted under P0-1; treat
+        // a missing row as "no reembed pending" rather than a hard error.
+        embedding_fingerprint_pending: read_axis_string_or_empty(
+            conn,
+            KEY_EMBEDDING_FINGERPRINT_PENDING,
+        )?,
         last_engine_version: read_axis_string(conn, KEY_LAST_ENGINE_VERSION)?,
     })
 }
@@ -154,6 +179,24 @@ pub fn read_migration_axes() -> Result<MigrationAxes, RagError> {
     read_axes_with(&conn)
 }
 
+/// Insert `(key, value)` only when the key is absent. Existing rows are left
+/// untouched — axes are sticky once written.
+fn insert_axis_if_absent(
+    conn: &Connection,
+    key: &str,
+    value: &str,
+) -> Result<bool, RagError> {
+    let changed = conn
+        .execute(
+            "INSERT INTO migration_meta(key, value)
+             VALUES (?1, ?2)
+             ON CONFLICT(key) DO NOTHING",
+            params![key, value],
+        )
+        .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    Ok(changed > 0)
+}
+
 fn bootstrap_axes(conn: &Connection, existing_install: bool) -> Result<bool, RagError> {
     let already_present: i64 = conn
         .query_row(
@@ -164,8 +207,10 @@ fn bootstrap_axes(conn: &Connection, existing_install: bool) -> Result<bool, Rag
         .map_err(|e| RagError::DatabaseError(e.to_string()))?;
 
     if already_present > 0 {
-        // Axes are sticky once written; only refresh the engine-version trace.
+        // Axes are sticky once written; only refresh the engine-version trace
+        // and backfill any axis keys introduced after this install's first boot.
         upsert_axis(conn, KEY_LAST_ENGINE_VERSION, CURRENT_ENGINE_VERSION)?;
+        insert_axis_if_absent(conn, KEY_EMBEDDING_FINGERPRINT_PENDING, EMPTY_FINGERPRINT)?;
         return Ok(false);
     }
 
@@ -180,14 +225,21 @@ fn bootstrap_axes(conn: &Connection, existing_install: bool) -> Result<bool, Rag
     };
 
     info!(
-        "[migration_meta] bootstrap: existing_install={}, sql={}, hnsw={}, bm25={}, fingerprint='{}', engine='{}'",
-        existing_install, sql_v, hnsw_v, bm25_v, EMPTY_FINGERPRINT, CURRENT_ENGINE_VERSION
+        "[migration_meta] bootstrap: existing_install={}, sql={}, hnsw={}, bm25={}, fingerprint='{}', pending='{}', engine='{}'",
+        existing_install,
+        sql_v,
+        hnsw_v,
+        bm25_v,
+        EMPTY_FINGERPRINT,
+        EMPTY_FINGERPRINT,
+        CURRENT_ENGINE_VERSION
     );
 
     upsert_axis(conn, KEY_SQL_SCHEMA_VERSION, &sql_v.to_string())?;
     upsert_axis(conn, KEY_HNSW_FORMAT_VERSION, &hnsw_v.to_string())?;
     upsert_axis(conn, KEY_BM25_STATS_VERSION, &bm25_v.to_string())?;
     upsert_axis(conn, KEY_EMBEDDING_FINGERPRINT, EMPTY_FINGERPRINT)?;
+    upsert_axis(conn, KEY_EMBEDDING_FINGERPRINT_PENDING, EMPTY_FINGERPRINT)?;
     upsert_axis(conn, KEY_LAST_ENGINE_VERSION, CURRENT_ENGINE_VERSION)?;
     Ok(true)
 }
@@ -219,6 +271,253 @@ fn assert_no_unknown_future_axes(axes: &MigrationAxes) -> Result<(), RagError> {
         CURRENT_BM25_STATS_VERSION,
     )?;
     Ok(())
+}
+
+/// Describes whether the on-device embedding store is compatible with the
+/// currently loaded model. Returned by [`detect_embedding_fingerprint_gate`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmbeddingFingerprintGate {
+    /// No fingerprint persisted yet; caller should write the current one
+    /// before serving any requests. First-ever boot.
+    RequiresInitialBaseline,
+    /// Stored fingerprint matches `current_fingerprint`; safe to proceed.
+    Ok,
+    /// Stored fingerprint differs from `current_fingerprint`; reads and
+    /// writes MUST be locked until either reembed completes or the user
+    /// explicitly confirms a clear-and-restart.
+    Mismatch {
+        stored: String,
+        current: String,
+        /// Number of chunk rows still tagged with a non-current fingerprint.
+        /// Useful for surfacing a "resume from N%" UI without an extra
+        /// round-trip to count chunks.
+        remaining_chunks: i64,
+        /// True when `embedding_fingerprint_pending` already equals
+        /// `current_fingerprint` — i.e. a reembed was previously started and
+        /// can simply continue without a fresh user confirmation.
+        resume_in_progress: bool,
+    },
+}
+
+/// Inspect `migration_meta` against the currently loaded model fingerprint.
+///
+/// This call only **reads** state — it never mutates `embedding_fingerprint`
+/// nor deletes embeddings. The caller is responsible for routing the gate
+/// state to the user (Apply, Rebuild, Invalidate decisions per the data
+/// migration plan).
+pub fn detect_embedding_fingerprint_gate(
+    current_fingerprint: String,
+) -> Result<EmbeddingFingerprintGate, RagError> {
+    if current_fingerprint.is_empty() {
+        return Err(RagError::InvalidInput(
+            "current_fingerprint must be non-empty".to_string(),
+        ));
+    }
+    let conn = get_connection().map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    let stored = read_axis_string(&conn, KEY_EMBEDDING_FINGERPRINT)?;
+    let pending = read_axis_string_or_empty(&conn, KEY_EMBEDDING_FINGERPRINT_PENDING)?;
+
+    if stored.is_empty() {
+        return Ok(EmbeddingFingerprintGate::RequiresInitialBaseline);
+    }
+    if stored == current_fingerprint {
+        return Ok(EmbeddingFingerprintGate::Ok);
+    }
+
+    let remaining = count_chunks_with_non_matching_fingerprint(&conn, &current_fingerprint)?;
+    let resume_in_progress = !pending.is_empty() && pending == current_fingerprint;
+    Ok(EmbeddingFingerprintGate::Mismatch {
+        stored,
+        current: current_fingerprint,
+        remaining_chunks: remaining,
+        resume_in_progress,
+    })
+}
+
+fn count_chunks_with_non_matching_fingerprint(
+    conn: &Connection,
+    target: &str,
+) -> Result<i64, RagError> {
+    conn.query_row(
+        "SELECT COUNT(*) FROM chunks
+         WHERE COALESCE(embedding_fingerprint, '') <> ?1",
+        params![target],
+        |row| row.get(0),
+    )
+    .map_err(|e| RagError::DatabaseError(e.to_string()))
+}
+
+/// Record the engine's current model fingerprint as the persisted baseline.
+///
+/// Only callable when no baseline is present yet — i.e. when the previous
+/// [`detect_embedding_fingerprint_gate`] returned
+/// [`EmbeddingFingerprintGate::RequiresInitialBaseline`]. After this call,
+/// every existing chunk is tagged as belonging to `fingerprint` so future
+/// mismatches can compute `remaining_chunks` accurately.
+///
+/// Refuses to overwrite a non-empty baseline. Use the reembed/clear flows
+/// to rotate an existing fingerprint instead.
+pub fn write_embedding_fingerprint(fingerprint: String) -> Result<(), RagError> {
+    if fingerprint.is_empty() {
+        return Err(RagError::InvalidInput(
+            "fingerprint must be non-empty".to_string(),
+        ));
+    }
+    let mut conn = get_connection().map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    let tx = conn
+        .transaction()
+        .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    let stored = read_axis_string(&tx, KEY_EMBEDDING_FINGERPRINT)?;
+    if !stored.is_empty() && stored != fingerprint {
+        return Err(RagError::InvalidInput(format!(
+            "embedding_fingerprint already set to '{stored}'; use the reembed \
+             or clear-and-restart flows to rotate it (refusing to overwrite)"
+        )));
+    }
+    upsert_axis(&tx, KEY_EMBEDDING_FINGERPRINT, &fingerprint)?;
+    // Backfill chunks so future mismatch detection counts accurately.
+    tx.execute(
+        "UPDATE chunks
+         SET embedding_fingerprint = ?1
+         WHERE COALESCE(embedding_fingerprint, '') = ''",
+        params![fingerprint],
+    )
+    .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    tx.commit()
+        .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    info!(
+        "[migration_meta] embedding_fingerprint baseline set to '{}'",
+        fingerprint
+    );
+    Ok(())
+}
+
+/// Begin a reembed-to-`target_fingerprint` flow.
+///
+/// Writes `embedding_fingerprint_pending = target_fingerprint` (sticky across
+/// reboots, so the flow is resumable) and returns the number of chunks that
+/// still need re-embedding. Idempotent — calling it again with the same
+/// target is safe.
+pub fn begin_embedding_reembed(target_fingerprint: String) -> Result<i64, RagError> {
+    if target_fingerprint.is_empty() {
+        return Err(RagError::InvalidInput(
+            "target_fingerprint must be non-empty".to_string(),
+        ));
+    }
+    let conn = get_connection().map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    let pending = read_axis_string_or_empty(&conn, KEY_EMBEDDING_FINGERPRINT_PENDING)?;
+    if !pending.is_empty() && pending != target_fingerprint {
+        return Err(RagError::InvalidInput(format!(
+            "reembed already pending towards '{pending}'; cannot retarget to \
+             '{target_fingerprint}'"
+        )));
+    }
+    upsert_axis(&conn, KEY_EMBEDDING_FINGERPRINT_PENDING, &target_fingerprint)?;
+    let remaining = count_chunks_with_non_matching_fingerprint(&conn, &target_fingerprint)?;
+    info!(
+        "[migration_meta] reembed started: target='{}', remaining_chunks={}",
+        target_fingerprint, remaining
+    );
+    Ok(remaining)
+}
+
+/// Count chunks still tagged with anything other than `target_fingerprint`.
+///
+/// Reads only — safe to call during progress polling.
+pub fn count_chunks_needing_reembed(target_fingerprint: String) -> Result<i64, RagError> {
+    if target_fingerprint.is_empty() {
+        return Err(RagError::InvalidInput(
+            "target_fingerprint must be non-empty".to_string(),
+        ));
+    }
+    let conn = get_connection().map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    count_chunks_with_non_matching_fingerprint(&conn, &target_fingerprint)
+}
+
+/// Commit a completed reembed atomically.
+///
+/// Refuses to commit when any chunk still carries a non-matching fingerprint,
+/// guarding against accidentally promoting `embedding_fingerprint` past a
+/// partially completed run. On success: `embedding_fingerprint = target`,
+/// `embedding_fingerprint_pending = ""`.
+pub fn finalize_embedding_reembed(target_fingerprint: String) -> Result<(), RagError> {
+    if target_fingerprint.is_empty() {
+        return Err(RagError::InvalidInput(
+            "target_fingerprint must be non-empty".to_string(),
+        ));
+    }
+    let mut conn = get_connection().map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    let tx = conn
+        .transaction()
+        .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    let remaining = count_chunks_with_non_matching_fingerprint(&tx, &target_fingerprint)?;
+    if remaining > 0 {
+        return Err(RagError::InvalidInput(format!(
+            "cannot finalize reembed: {remaining} chunk(s) still carry a \
+             non-target fingerprint"
+        )));
+    }
+    upsert_axis(&tx, KEY_EMBEDDING_FINGERPRINT, &target_fingerprint)?;
+    upsert_axis(&tx, KEY_EMBEDDING_FINGERPRINT_PENDING, EMPTY_FINGERPRINT)?;
+    tx.commit()
+        .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    info!(
+        "[migration_meta] reembed finalized: stored='{}', pending=''",
+        target_fingerprint
+    );
+    Ok(())
+}
+
+/// Magic confirmation string that callers must pass to
+/// [`acknowledge_and_clear_embeddings`] to opt into destructive deletion.
+/// The Dart facade wraps this behind a typed confirmation parameter so the
+/// destructive choice is explicit at the call site.
+pub const EMBEDDING_CLEAR_CONFIRMATION: &str =
+    "I_UNDERSTAND_THIS_DELETES_ALL_ON_DEVICE_EMBEDDINGS";
+
+/// Discard every chunk row (and therefore every embedding BLOB) for sources
+/// the user has accepted as lost, then reset the fingerprint axes.
+///
+/// Refuses to do anything unless `confirmation` exactly equals
+/// [`EMBEDDING_CLEAR_CONFIRMATION`]. This is the only public path that may
+/// drop user embeddings; it must never be reachable from passive flows.
+///
+/// The `sources` rows are kept so the user can re-ingest them through the
+/// normal ingestion path; only `chunks` (which hold the embeddings) are
+/// removed.
+pub fn acknowledge_and_clear_embeddings(
+    confirmation: String,
+    new_fingerprint: String,
+) -> Result<i64, RagError> {
+    if confirmation != EMBEDDING_CLEAR_CONFIRMATION {
+        return Err(RagError::InvalidInput(
+            "refusing to clear embeddings: confirmation token missing or \
+             does not match EMBEDDING_CLEAR_CONFIRMATION"
+                .to_string(),
+        ));
+    }
+    if new_fingerprint.is_empty() {
+        return Err(RagError::InvalidInput(
+            "new_fingerprint must be non-empty when clearing embeddings"
+                .to_string(),
+        ));
+    }
+    let mut conn = get_connection().map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    let tx = conn
+        .transaction()
+        .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    let deleted = tx
+        .execute("DELETE FROM chunks", [])
+        .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    upsert_axis(&tx, KEY_EMBEDDING_FINGERPRINT, &new_fingerprint)?;
+    upsert_axis(&tx, KEY_EMBEDDING_FINGERPRINT_PENDING, EMPTY_FINGERPRINT)?;
+    tx.commit()
+        .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    info!(
+        "[migration_meta] embeddings cleared with confirmation; deleted={} chunks, new fingerprint='{}'",
+        deleted, new_fingerprint
+    );
+    Ok(deleted as i64)
 }
 
 /// Bootstrap or refresh `migration_meta` in a single transaction and return
@@ -289,6 +588,31 @@ mod tests {
             .unwrap();
     }
 
+    fn provision_chunks_table() {
+        let conn = get_connection().unwrap();
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS chunks (
+                id INTEGER PRIMARY KEY,
+                content TEXT NOT NULL,
+                embedding BLOB,
+                embedding_fingerprint TEXT
+            )",
+            [],
+        )
+        .unwrap();
+    }
+
+    fn insert_chunk(content: &str, fingerprint: Option<&str>) -> i64 {
+        let conn = get_connection().unwrap();
+        conn.execute(
+            "INSERT INTO chunks(content, embedding, embedding_fingerprint)
+             VALUES (?1, ?2, ?3)",
+            rusqlite::params![content, vec![0u8; 4], fingerprint],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
     #[test]
     fn new_install_records_current_axes() {
         let pool = fresh_pool();
@@ -297,6 +621,7 @@ mod tests {
         assert_eq!(axes.hnsw_format_version, CURRENT_HNSW_FORMAT_VERSION);
         assert_eq!(axes.bm25_stats_version, CURRENT_BM25_STATS_VERSION);
         assert_eq!(axes.embedding_fingerprint, EMPTY_FINGERPRINT);
+        assert_eq!(axes.embedding_fingerprint_pending, EMPTY_FINGERPRINT);
         assert_eq!(axes.last_engine_version, CURRENT_ENGINE_VERSION);
         drop(pool);
     }
@@ -320,9 +645,177 @@ mod tests {
         assert_eq!(axes.hnsw_format_version, 0);
         assert_eq!(axes.bm25_stats_version, 0);
         assert_eq!(axes.embedding_fingerprint, EMPTY_FINGERPRINT);
+        assert_eq!(axes.embedding_fingerprint_pending, EMPTY_FINGERPRINT);
         assert_eq!(axes.last_engine_version, CURRENT_ENGINE_VERSION);
 
         close_db_pool();
+    }
+
+    #[test]
+    fn p0_1_install_backfills_pending_axis() {
+        // Simulate a database that booted under P0-1 (no pending axis key).
+        let pool = fresh_pool();
+        initialize_migration_meta(false).unwrap();
+        {
+            let conn = get_connection().unwrap();
+            conn.execute(
+                "DELETE FROM migration_meta WHERE key = ?1",
+                params![KEY_EMBEDDING_FINGERPRINT_PENDING],
+            )
+            .unwrap();
+        }
+        let axes = initialize_migration_meta(true).unwrap();
+        assert_eq!(
+            axes.embedding_fingerprint_pending, EMPTY_FINGERPRINT,
+            "missing pending axis must be silently backfilled to empty"
+        );
+        drop(pool);
+    }
+
+    #[test]
+    fn gate_requires_baseline_on_empty_fingerprint() {
+        let pool = fresh_pool();
+        initialize_migration_meta(false).unwrap();
+        let gate = detect_embedding_fingerprint_gate("model|384|f32".to_string()).unwrap();
+        assert!(matches!(gate, EmbeddingFingerprintGate::RequiresInitialBaseline));
+        drop(pool);
+    }
+
+    #[test]
+    fn gate_ok_when_stored_matches_current() {
+        let pool = fresh_pool();
+        initialize_migration_meta(false).unwrap();
+        provision_chunks_table();
+        write_embedding_fingerprint("model|384|f32".to_string()).unwrap();
+        let gate = detect_embedding_fingerprint_gate("model|384|f32".to_string()).unwrap();
+        assert!(matches!(gate, EmbeddingFingerprintGate::Ok));
+        drop(pool);
+    }
+
+    #[test]
+    fn gate_mismatch_reports_remaining_chunks() {
+        let pool = fresh_pool();
+        initialize_migration_meta(false).unwrap();
+        provision_chunks_table();
+        write_embedding_fingerprint("old|384|f32".to_string()).unwrap();
+        insert_chunk("c1", Some("old|384|f32"));
+        insert_chunk("c2", Some("old|384|f32"));
+
+        let gate = detect_embedding_fingerprint_gate("new|384|f32".to_string()).unwrap();
+        match gate {
+            EmbeddingFingerprintGate::Mismatch {
+                stored,
+                current,
+                remaining_chunks,
+                resume_in_progress,
+            } => {
+                assert_eq!(stored, "old|384|f32");
+                assert_eq!(current, "new|384|f32");
+                assert_eq!(remaining_chunks, 2);
+                assert!(!resume_in_progress);
+            }
+            other => panic!("expected Mismatch, got {:?}", other),
+        }
+        drop(pool);
+    }
+
+    #[test]
+    fn reembed_lifecycle_progresses_and_finalizes() {
+        let pool = fresh_pool();
+        initialize_migration_meta(false).unwrap();
+        provision_chunks_table();
+        write_embedding_fingerprint("old".to_string()).unwrap();
+        let c1 = insert_chunk("alpha", Some("old"));
+        let c2 = insert_chunk("beta", Some("old"));
+
+        let remaining = begin_embedding_reembed("new".to_string()).unwrap();
+        assert_eq!(remaining, 2);
+
+        // Resume signal becomes visible after begin_embedding_reembed.
+        match detect_embedding_fingerprint_gate("new".to_string()).unwrap() {
+            EmbeddingFingerprintGate::Mismatch {
+                resume_in_progress, ..
+            } => assert!(resume_in_progress),
+            other => panic!("expected Mismatch, got {:?}", other),
+        }
+
+        // Tag the chunks one at a time and watch the remaining count drop.
+        {
+            let conn = get_connection().unwrap();
+            conn.execute(
+                "UPDATE chunks SET embedding_fingerprint = 'new' WHERE id = ?1",
+                params![c1],
+            )
+            .unwrap();
+        }
+        assert_eq!(count_chunks_needing_reembed("new".to_string()).unwrap(), 1);
+
+        // Finalize before completion must fail.
+        match finalize_embedding_reembed("new".to_string()) {
+            Err(RagError::InvalidInput(msg)) => {
+                assert!(msg.contains("1 chunk"), "got: {msg}")
+            }
+            other => panic!("expected InvalidInput, got {:?}", other),
+        }
+
+        {
+            let conn = get_connection().unwrap();
+            conn.execute(
+                "UPDATE chunks SET embedding_fingerprint = 'new' WHERE id = ?1",
+                params![c2],
+            )
+            .unwrap();
+        }
+        finalize_embedding_reembed("new".to_string()).unwrap();
+        let axes = read_migration_axes().unwrap();
+        assert_eq!(axes.embedding_fingerprint, "new");
+        assert_eq!(axes.embedding_fingerprint_pending, EMPTY_FINGERPRINT);
+        drop(pool);
+    }
+
+    #[test]
+    fn clear_requires_confirmation_token() {
+        let pool = fresh_pool();
+        initialize_migration_meta(false).unwrap();
+        provision_chunks_table();
+        write_embedding_fingerprint("old".to_string()).unwrap();
+        insert_chunk("alpha", Some("old"));
+
+        match acknowledge_and_clear_embeddings("NOPE".to_string(), "new".to_string()) {
+            Err(RagError::InvalidInput(msg)) => {
+                assert!(msg.contains("confirmation"), "got: {msg}")
+            }
+            other => panic!("expected InvalidInput, got {:?}", other),
+        }
+        // Chunk must still exist after a refused clear — destructive paths
+        // are gated behind the explicit confirmation token only.
+        let conn = get_connection().unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunks", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        drop(pool);
+    }
+
+    #[test]
+    fn clear_with_confirmation_wipes_chunks_and_rotates_axis() {
+        let pool = fresh_pool();
+        initialize_migration_meta(false).unwrap();
+        provision_chunks_table();
+        write_embedding_fingerprint("old".to_string()).unwrap();
+        insert_chunk("alpha", Some("old"));
+        insert_chunk("beta", Some("old"));
+
+        let deleted = acknowledge_and_clear_embeddings(
+            EMBEDDING_CLEAR_CONFIRMATION.to_string(),
+            "new".to_string(),
+        )
+        .unwrap();
+        assert_eq!(deleted, 2);
+        let axes = read_migration_axes().unwrap();
+        assert_eq!(axes.embedding_fingerprint, "new");
+        assert_eq!(axes.embedding_fingerprint_pending, EMPTY_FINGERPRINT);
+        drop(pool);
     }
 
     #[test]

--- a/rust_builder/rust/src/api/source_rag.rs
+++ b/rust_builder/rust/src/api/source_rag.rs
@@ -372,6 +372,18 @@ pub fn init_source_db() -> Result<(), RagError> {
             .map_err(|e| RagError::DatabaseError(e.to_string()))?;
     }
 
+    let has_chunk_embedding_fingerprint: bool = conn
+        .prepare("SELECT embedding_fingerprint FROM chunks LIMIT 1")
+        .is_ok();
+    if !has_chunk_embedding_fingerprint {
+        info!("[init_source_db] Migrating: adding embedding_fingerprint to chunks");
+        conn.execute(
+            "ALTER TABLE chunks ADD COLUMN embedding_fingerprint TEXT",
+            [],
+        )
+        .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    }
+
     #[cfg(feature = "vector_quant_i8")]
     {
         let mut stmt = conn.prepare(
@@ -2606,6 +2618,95 @@ pub fn update_chunk_embedding(chunk_id: i64, embedding: Vec<f32>) -> Result<(), 
         params![embedding_bytes, chunk_id],
     )
     .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    if let Some(cid) = collection_id {
+        mark_collection_dirty(&conn, &cid)?;
+    }
+    Ok(())
+}
+
+/// Stream the next batch of chunks that still carry a non-matching fingerprint.
+///
+/// Used by the reembed flow to walk the corpus incrementally without holding
+/// the entire chunk set in Dart memory. The batch is ordered by `id` so a
+/// caller that crashes between batches can resume deterministically.
+pub fn list_chunks_needing_reembed(
+    target_fingerprint: String,
+    limit: i64,
+) -> Result<Vec<ChunkForReembedding>, RagError> {
+    if target_fingerprint.is_empty() {
+        return Err(RagError::InvalidInput(
+            "target_fingerprint must be non-empty".to_string(),
+        ));
+    }
+    if limit <= 0 {
+        return Err(RagError::InvalidInput(
+            "limit must be greater than zero".to_string(),
+        ));
+    }
+    let conn = get_connection().map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, content FROM chunks
+             WHERE COALESCE(embedding_fingerprint, '') <> ?1
+             ORDER BY id
+             LIMIT ?2",
+        )
+        .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    let chunks: Vec<ChunkForReembedding> = stmt
+        .query_map(params![target_fingerprint, limit], |row| {
+            Ok(ChunkForReembedding {
+                chunk_id: row.get(0)?,
+                content: row.get(1)?,
+            })
+        })
+        .map_err(|e| RagError::DatabaseError(e.to_string()))?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(chunks)
+}
+
+/// Atomically replace a chunk's embedding and tag it with `target_fingerprint`.
+///
+/// Single-statement UPDATE so a crash mid-write cannot leave a chunk with the
+/// new embedding bytes but the old fingerprint marker (or vice versa). Marks
+/// the chunk's collection as dirty so the next HNSW rebuild picks up the new
+/// vector.
+pub fn update_chunk_reembedded(
+    chunk_id: i64,
+    embedding: Vec<f32>,
+    target_fingerprint: String,
+) -> Result<(), RagError> {
+    if target_fingerprint.is_empty() {
+        return Err(RagError::InvalidInput(
+            "target_fingerprint must be non-empty".to_string(),
+        ));
+    }
+    let conn = get_connection().map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    let collection_id: Option<String> = conn
+        .query_row(
+            "SELECT collection_id FROM chunks WHERE id = ?1",
+            params![chunk_id],
+            |row| row.get(0),
+        )
+        .ok();
+    let mut embedding_bytes: Vec<u8> = Vec::with_capacity(embedding.len() * 4);
+    for f in &embedding {
+        embedding_bytes.extend_from_slice(&f.to_ne_bytes());
+    }
+    let updated = conn
+        .execute(
+            "UPDATE chunks
+             SET embedding = ?1,
+                 embedding_fingerprint = ?2
+             WHERE id = ?3",
+            params![embedding_bytes, target_fingerprint, chunk_id],
+        )
+        .map_err(|e| RagError::DatabaseError(e.to_string()))?;
+    if updated == 0 {
+        return Err(RagError::DatabaseError(format!(
+            "no chunk with id={chunk_id} (reembed update was a no-op)"
+        )));
+    }
     if let Some(cid) = collection_id {
         mark_collection_dirty(&conn, &cid)?;
     }

--- a/rust_builder/rust/src/frb_generated.rs
+++ b/rust_builder/rust/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1936558543;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 907237406;
 
 // Section: executor
 
@@ -798,6 +798,43 @@ fn wire__crate__api__source_rag__SearchHandle_hydrate_chunks_impl(
         },
     )
 }
+fn wire__crate__api__migration_meta__acknowledge_and_clear_embeddings_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "acknowledge_and_clear_embeddings",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_confirmation = <String>::sse_decode(&mut deserializer);
+            let api_new_fingerprint = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::error::RagError>((move || {
+                    let output_ok = crate::api::migration_meta::acknowledge_and_clear_embeddings(
+                        api_confirmation,
+                        api_new_fingerprint,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__source_rag__activate_collection_for_hybrid_search_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -1016,6 +1053,41 @@ fn wire__crate__api__source_rag__add_source_in_collection_impl(
                         api_content,
                         api_metadata,
                         api_name,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__migration_meta__begin_embedding_reembed_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "begin_embedding_reembed",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_target_fingerprint = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::error::RagError>((move || {
+                    let output_ok = crate::api::migration_meta::begin_embedding_reembed(
+                        api_target_fingerprint,
                     )?;
                     Ok(output_ok)
                 })())
@@ -1825,6 +1897,41 @@ fn wire__crate__api__compression_utils__compression_options_default_impl(
         },
     )
 }
+fn wire__crate__api__migration_meta__count_chunks_needing_reembed_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "count_chunks_needing_reembed",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_target_fingerprint = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::error::RagError>((move || {
+                    let output_ok = crate::api::migration_meta::count_chunks_needing_reembed(
+                        api_target_fingerprint,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__tokenizer__count_tokens_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -1997,6 +2104,41 @@ fn wire__crate__api__source_rag__derive_context_budget_for_prompt_v2_impl(
                         api_use_strict_mode,
                         api_safety_margin_tokens,
                         api_fixed_prompt_overhead_tokens,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__migration_meta__detect_embedding_fingerprint_gate_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "detect_embedding_fingerprint_gate",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_current_fingerprint = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::error::RagError>((move || {
+                    let output_ok = crate::api::migration_meta::detect_embedding_fingerprint_gate(
+                        api_current_fingerprint,
                     )?;
                     Ok(output_ok)
                 })())
@@ -2217,6 +2359,41 @@ fn wire__crate__api__document_parser__extract_text_from_utf8_impl(
                         Ok(output_ok)
                     })(),
                 )
+            }
+        },
+    )
+}
+fn wire__crate__api__migration_meta__finalize_embedding_reembed_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "finalize_embedding_reembed",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_target_fingerprint = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::error::RagError>((move || {
+                    let output_ok = crate::api::migration_meta::finalize_embedding_reembed(
+                        api_target_fingerprint,
+                    )?;
+                    Ok(output_ok)
+                })())
             }
         },
     )
@@ -3337,6 +3514,43 @@ fn wire__crate__api__db_pool__is_pool_initialized_impl(
                 transform_result_sse::<_, ()>((move || {
                     let output_ok =
                         Result::<_, ()>::Ok(crate::api::db_pool::is_pool_initialized())?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__source_rag__list_chunks_needing_reembed_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "list_chunks_needing_reembed",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_target_fingerprint = <String>::sse_decode(&mut deserializer);
+            let api_limit = <i64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::error::RagError>((move || {
+                    let output_ok = crate::api::source_rag::list_chunks_needing_reembed(
+                        api_target_fingerprint,
+                        api_limit,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -4950,6 +5164,45 @@ fn wire__crate__api__source_rag__update_chunk_embedding_impl(
         },
     )
 }
+fn wire__crate__api__source_rag__update_chunk_reembedded_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "update_chunk_reembedded",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_chunk_id = <i64>::sse_decode(&mut deserializer);
+            let api_embedding = <Vec<f32>>::sse_decode(&mut deserializer);
+            let api_target_fingerprint = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::error::RagError>((move || {
+                    let output_ok = crate::api::source_rag::update_chunk_reembedded(
+                        api_chunk_id,
+                        api_embedding,
+                        api_target_fingerprint,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__source_rag__update_source_status_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -5049,6 +5302,40 @@ fn wire__crate__api__user_intent__user_intent_intent_type_impl(
                     let output_ok = Result::<_, ()>::Ok({
                         crate::api::user_intent::UserIntent::intent_type(&api_that);
                     })?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__migration_meta__write_embedding_fingerprint_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "write_embedding_fingerprint",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_fingerprint = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::api::error::RagError>((move || {
+                    let output_ok =
+                        crate::api::migration_meta::write_embedding_fingerprint(api_fingerprint)?;
                     Ok(output_ok)
                 })())
             }
@@ -5399,6 +5686,36 @@ impl SseDecode for crate::api::source_rag::ContextAssemblyStrategy {
             2 => crate::api::source_rag::ContextAssemblyStrategy::Chronological,
             _ => unreachable!("Invalid variant for ContextAssemblyStrategy: {}", inner),
         };
+    }
+}
+
+impl SseDecode for crate::api::migration_meta::EmbeddingFingerprintGate {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut tag_ = <i32>::sse_decode(deserializer);
+        match tag_ {
+            0 => {
+                return crate::api::migration_meta::EmbeddingFingerprintGate::RequiresInitialBaseline;
+            }
+            1 => {
+                return crate::api::migration_meta::EmbeddingFingerprintGate::Ok;
+            }
+            2 => {
+                let mut var_stored = <String>::sse_decode(deserializer);
+                let mut var_current = <String>::sse_decode(deserializer);
+                let mut var_remainingChunks = <i64>::sse_decode(deserializer);
+                let mut var_resumeInProgress = <bool>::sse_decode(deserializer);
+                return crate::api::migration_meta::EmbeddingFingerprintGate::Mismatch {
+                    stored: var_stored,
+                    current: var_current,
+                    remaining_chunks: var_remainingChunks,
+                    resume_in_progress: var_resumeInProgress,
+                };
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
     }
 }
 
@@ -5841,12 +6158,14 @@ impl SseDecode for crate::api::migration_meta::MigrationAxes {
         let mut var_hnswFormatVersion = <i64>::sse_decode(deserializer);
         let mut var_bm25StatsVersion = <i64>::sse_decode(deserializer);
         let mut var_embeddingFingerprint = <String>::sse_decode(deserializer);
+        let mut var_embeddingFingerprintPending = <String>::sse_decode(deserializer);
         let mut var_lastEngineVersion = <String>::sse_decode(deserializer);
         return crate::api::migration_meta::MigrationAxes {
             sql_schema_version: var_sqlSchemaVersion,
             hnsw_format_version: var_hnswFormatVersion,
             bm25_stats_version: var_bm25StatsVersion,
             embedding_fingerprint: var_embeddingFingerprint,
+            embedding_fingerprint_pending: var_embeddingFingerprintPending,
             last_engine_version: var_lastEngineVersion,
         };
     }
@@ -6103,6 +6422,14 @@ impl SseDecode for crate::api::error::RagError {
                 );
             }
             8 => {
+                let mut var_field0 = <String>::sse_decode(deserializer);
+                let mut var_field1 = <String>::sse_decode(deserializer);
+                let mut var_field2 = <i64>::sse_decode(deserializer);
+                return crate::api::error::RagError::EmbeddingFingerprintMismatch(
+                    var_field0, var_field1, var_field2,
+                );
+            }
+            9 => {
                 let mut var_field0 = <String>::sse_decode(deserializer);
                 return crate::api::error::RagError::Unknown(var_field0);
             }
@@ -6376,108 +6703,116 @@ fn pde_ffi_dispatcher_primary_impl(
 13 => wire__crate__api__source_rag__SearchHandle_get_chunk_excerpts_impl(port, ptr, rust_vec_len, data_len),
 14 => wire__crate__api__source_rag__SearchHandle_hit_meta_impl(port, ptr, rust_vec_len, data_len),
 15 => wire__crate__api__source_rag__SearchHandle_hydrate_chunks_impl(port, ptr, rust_vec_len, data_len),
-16 => wire__crate__api__source_rag__activate_collection_for_hybrid_search_impl(port, ptr, rust_vec_len, data_len),
-17 => wire__crate__api__source_rag__add_chunks_impl(port, ptr, rust_vec_len, data_len),
-18 => wire__crate__api__simple_rag__add_document_impl(port, ptr, rust_vec_len, data_len),
-19 => wire__crate__api__simple_rag__add_document_simple_impl(port, ptr, rust_vec_len, data_len),
-20 => wire__crate__api__source_rag__add_source_impl(port, ptr, rust_vec_len, data_len),
-21 => wire__crate__api__source_rag__add_source_in_collection_impl(port, ptr, rust_vec_len, data_len),
-22 => wire__crate__api__source_rag__benchmark_search_chunks_linear_in_collection_impl(port, ptr, rust_vec_len, data_len),
-23 => wire__crate__api__simple_rag__benchmark_search_linear_scan_impl(port, ptr, rust_vec_len, data_len),
-24 => wire__crate__api__bm25_search__bm25_add_document_impl(port, ptr, rust_vec_len, data_len),
-25 => wire__crate__api__bm25_search__bm25_add_documents_impl(port, ptr, rust_vec_len, data_len),
-26 => wire__crate__api__bm25_search__bm25_clear_index_impl(port, ptr, rust_vec_len, data_len),
-27 => wire__crate__api__bm25_search__bm25_get_document_count_impl(port, ptr, rust_vec_len, data_len),
-28 => wire__crate__api__bm25_search__bm25_remove_document_impl(port, ptr, rust_vec_len, data_len),
-29 => wire__crate__api__bm25_search__bm25_search_impl(port, ptr, rust_vec_len, data_len),
-30 => wire__crate__api__hnsw_index__build_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
-32 => wire__crate__api__semantic_chunker__chunk_type_as_str_impl(port, ptr, rust_vec_len, data_len),
-33 => wire__crate__api__semantic_chunker__chunk_type_from_str_impl(port, ptr, rust_vec_len, data_len),
-34 => wire__crate__api__source_rag__claim_source_for_ingestion_impl(port, ptr, rust_vec_len, data_len),
-36 => wire__crate__api__simple_rag__clear_all_documents_impl(port, ptr, rust_vec_len, data_len),
-37 => wire__crate__api__incremental_index__clear_buffer_impl(port, ptr, rust_vec_len, data_len),
-38 => wire__crate__api__hnsw_index__clear_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
-39 => wire__crate__api__source_rag__clear_source_chunks_impl(port, ptr, rust_vec_len, data_len),
-40 => wire__crate__api__db_pool__close_db_pool_impl(port, ptr, rust_vec_len, data_len),
-42 => wire__crate__api__compression_utils__compress_text_impl(port, ptr, rust_vec_len, data_len),
-43 => wire__crate__api__compression_utils__compress_text_simple_impl(port, ptr, rust_vec_len, data_len),
-44 => wire__crate__api__compression_utils__compression_options_default_impl(port, ptr, rust_vec_len, data_len),
-47 => wire__crate__api__source_rag__delete_source_impl(port, ptr, rust_vec_len, data_len),
-48 => wire__crate__api__source_rag__delete_source_in_collection_impl(port, ptr, rust_vec_len, data_len),
-49 => wire__crate__api__source_rag__derive_context_budget_for_prompt_v2_impl(port, ptr, rust_vec_len, data_len),
-50 => wire__crate__api__hnsw_index__embedding_point_new_impl(port, ptr, rust_vec_len, data_len),
-51 => wire__crate__api__document_parser__extract_text_from_document_impl(port, ptr, rust_vec_len, data_len),
-52 => wire__crate__api__document_parser__extract_text_from_docx_impl(port, ptr, rust_vec_len, data_len),
-53 => wire__crate__api__document_parser__extract_text_from_file_impl(port, ptr, rust_vec_len, data_len),
-54 => wire__crate__api__document_parser__extract_text_from_pdf_impl(port, ptr, rust_vec_len, data_len),
-55 => wire__crate__api__document_parser__extract_text_from_utf8_impl(port, ptr, rust_vec_len, data_len),
-56 => wire__crate__api__source_rag__get_adjacent_chunks_impl(port, ptr, rust_vec_len, data_len),
-57 => wire__crate__api__source_rag__get_all_chunk_ids_and_contents_impl(port, ptr, rust_vec_len, data_len),
-58 => wire__crate__api__source_rag__get_all_chunk_ids_and_contents_in_collection_impl(port, ptr, rust_vec_len, data_len),
-59 => wire__crate__api__incremental_index__get_buffer_for_merge_impl(port, ptr, rust_vec_len, data_len),
-60 => wire__crate__api__incremental_index__get_buffer_stats_impl(port, ptr, rust_vec_len, data_len),
-61 => wire__crate__api__simple_rag__get_document_count_impl(port, ptr, rust_vec_len, data_len),
-62 => wire__crate__api__db_pool__get_pool_stats_impl(port, ptr, rust_vec_len, data_len),
-63 => wire__crate__api__source_rag__get_source_impl(port, ptr, rust_vec_len, data_len),
-64 => wire__crate__api__source_rag__get_source_chunk_count_impl(port, ptr, rust_vec_len, data_len),
-65 => wire__crate__api__source_rag__get_source_chunks_impl(port, ptr, rust_vec_len, data_len),
-66 => wire__crate__api__source_rag__get_source_stats_impl(port, ptr, rust_vec_len, data_len),
-67 => wire__crate__api__source_rag__get_source_stats_in_collection_impl(port, ptr, rust_vec_len, data_len),
-68 => wire__crate__api__source_rag__get_source_status_impl(port, ptr, rust_vec_len, data_len),
-71 => wire__crate__api__incremental_index__incremental_add_impl(port, ptr, rust_vec_len, data_len),
-72 => wire__crate__api__incremental_index__incremental_add_batch_impl(port, ptr, rust_vec_len, data_len),
-73 => wire__crate__api__incremental_index__incremental_remove_impl(port, ptr, rust_vec_len, data_len),
-74 => wire__crate__api__incremental_index__incremental_search_impl(port, ptr, rust_vec_len, data_len),
-76 => wire__crate__api__ingest_metrics__ingest_traffic_stats_legacy_text_traffic_total_impl(port, ptr, rust_vec_len, data_len),
-77 => wire__crate__api__ingest_metrics__ingest_traffic_stats_session_text_traffic_total_impl(port, ptr, rust_vec_len, data_len),
-78 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-79 => wire__crate__api__simple_rag__init_db_impl(port, ptr, rust_vec_len, data_len),
-80 => wire__crate__api__db_pool__init_db_pool_impl(port, ptr, rust_vec_len, data_len),
-82 => wire__crate__api__logger__init_logger_impl(port, ptr, rust_vec_len, data_len),
-83 => wire__crate__api__source_rag__init_source_db_impl(port, ptr, rust_vec_len, data_len),
-84 => wire__crate__api__tokenizer__init_tokenizer_impl(port, ptr, rust_vec_len, data_len),
-85 => wire__crate__api__bm25_search__is_bm25_index_loaded_impl(port, ptr, rust_vec_len, data_len),
-86 => wire__crate__api__source_rag__is_chunk_bm25_index_loaded_impl(port, ptr, rust_vec_len, data_len),
-87 => wire__crate__api__hnsw_index__is_hnsw_index_loaded_impl(port, ptr, rust_vec_len, data_len),
-88 => wire__crate__api__db_pool__is_pool_initialized_impl(port, ptr, rust_vec_len, data_len),
-89 => wire__crate__api__source_rag__list_sources_impl(port, ptr, rust_vec_len, data_len),
-90 => wire__crate__api__source_rag__list_sources_in_collection_impl(port, ptr, rust_vec_len, data_len),
-91 => wire__crate__api__source_rag__load_collection_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
-92 => wire__crate__api__hnsw_index__load_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
-94 => wire__crate__api__incremental_index__needs_merge_impl(port, ptr, rust_vec_len, data_len),
-97 => wire__crate__api__ingest_session__prepare_source_ingestion_impl(port, ptr, rust_vec_len, data_len),
-98 => wire__crate__api__ingest_session__prepare_source_ingestion_from_file_impl(port, ptr, rust_vec_len, data_len),
-99 => wire__crate__api__ingest_session__prepare_source_ingestion_from_utf8_impl(port, ptr, rust_vec_len, data_len),
-101 => wire__crate__api__query_metrics__query_content_read_stats_content_bytes_total_impl(port, ptr, rust_vec_len, data_len),
-102 => wire__crate__api__query_metrics__query_content_read_stats_hydration_content_bytes_total_impl(port, ptr, rust_vec_len, data_len),
-103 => wire__crate__api__query_metrics__query_content_read_stats_hydration_rows_total_impl(port, ptr, rust_vec_len, data_len),
-104 => wire__crate__api__query_metrics__query_content_read_stats_rows_total_impl(port, ptr, rust_vec_len, data_len),
-105 => wire__crate__api__migration_meta__read_migration_axes_impl(port, ptr, rust_vec_len, data_len),
-106 => wire__crate__api__simple_rag__rebuild_bm25_index_impl(port, ptr, rust_vec_len, data_len),
-107 => wire__crate__api__source_rag__rebuild_chunk_bm25_index_impl(port, ptr, rust_vec_len, data_len),
-108 => wire__crate__api__source_rag__rebuild_chunk_bm25_index_for_collection_impl(port, ptr, rust_vec_len, data_len),
-109 => wire__crate__api__source_rag__rebuild_chunk_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
-110 => wire__crate__api__source_rag__rebuild_chunk_hnsw_index_for_collection_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__simple_rag__rebuild_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__hybrid_search__rrf_config_default_impl(port, ptr, rust_vec_len, data_len),
-115 => wire__crate__api__source_rag__save_collection_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
-116 => wire__crate__api__hnsw_index__save_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
-117 => wire__crate__api__source_rag__search_chunks_impl(port, ptr, rust_vec_len, data_len),
-118 => wire__crate__api__source_rag__search_chunks_in_collection_impl(port, ptr, rust_vec_len, data_len),
-119 => wire__crate__api__hnsw_index__search_hnsw_impl(port, ptr, rust_vec_len, data_len),
-120 => wire__crate__api__hnsw_index__search_hnsw_slice_impl(port, ptr, rust_vec_len, data_len),
-121 => wire__crate__api__hybrid_search__search_hybrid_impl(port, ptr, rust_vec_len, data_len),
-122 => wire__crate__api__hybrid_search__search_hybrid_simple_impl(port, ptr, rust_vec_len, data_len),
-123 => wire__crate__api__hybrid_search__search_hybrid_weighted_impl(port, ptr, rust_vec_len, data_len),
-124 => wire__crate__api__source_rag__search_meta_hybrid_impl(port, ptr, rust_vec_len, data_len),
-125 => wire__crate__api__simple_rag__search_similar_impl(port, ptr, rust_vec_len, data_len),
-128 => wire__crate__api__compression_utils__sentence_hash_impl(port, ptr, rust_vec_len, data_len),
-129 => wire__crate__api__compression_utils__should_compress_impl(port, ptr, rust_vec_len, data_len),
-130 => wire__crate__api__compression_utils__split_sentences_impl(port, ptr, rust_vec_len, data_len),
-133 => wire__crate__api__source_rag__update_chunk_embedding_impl(port, ptr, rust_vec_len, data_len),
-134 => wire__crate__api__source_rag__update_source_status_impl(port, ptr, rust_vec_len, data_len),
-135 => wire__crate__api__user_intent__user_intent_get_query_impl(port, ptr, rust_vec_len, data_len),
-136 => wire__crate__api__user_intent__user_intent_intent_type_impl(port, ptr, rust_vec_len, data_len),
+16 => wire__crate__api__migration_meta__acknowledge_and_clear_embeddings_impl(port, ptr, rust_vec_len, data_len),
+17 => wire__crate__api__source_rag__activate_collection_for_hybrid_search_impl(port, ptr, rust_vec_len, data_len),
+18 => wire__crate__api__source_rag__add_chunks_impl(port, ptr, rust_vec_len, data_len),
+19 => wire__crate__api__simple_rag__add_document_impl(port, ptr, rust_vec_len, data_len),
+20 => wire__crate__api__simple_rag__add_document_simple_impl(port, ptr, rust_vec_len, data_len),
+21 => wire__crate__api__source_rag__add_source_impl(port, ptr, rust_vec_len, data_len),
+22 => wire__crate__api__source_rag__add_source_in_collection_impl(port, ptr, rust_vec_len, data_len),
+23 => wire__crate__api__migration_meta__begin_embedding_reembed_impl(port, ptr, rust_vec_len, data_len),
+24 => wire__crate__api__source_rag__benchmark_search_chunks_linear_in_collection_impl(port, ptr, rust_vec_len, data_len),
+25 => wire__crate__api__simple_rag__benchmark_search_linear_scan_impl(port, ptr, rust_vec_len, data_len),
+26 => wire__crate__api__bm25_search__bm25_add_document_impl(port, ptr, rust_vec_len, data_len),
+27 => wire__crate__api__bm25_search__bm25_add_documents_impl(port, ptr, rust_vec_len, data_len),
+28 => wire__crate__api__bm25_search__bm25_clear_index_impl(port, ptr, rust_vec_len, data_len),
+29 => wire__crate__api__bm25_search__bm25_get_document_count_impl(port, ptr, rust_vec_len, data_len),
+30 => wire__crate__api__bm25_search__bm25_remove_document_impl(port, ptr, rust_vec_len, data_len),
+31 => wire__crate__api__bm25_search__bm25_search_impl(port, ptr, rust_vec_len, data_len),
+32 => wire__crate__api__hnsw_index__build_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
+34 => wire__crate__api__semantic_chunker__chunk_type_as_str_impl(port, ptr, rust_vec_len, data_len),
+35 => wire__crate__api__semantic_chunker__chunk_type_from_str_impl(port, ptr, rust_vec_len, data_len),
+36 => wire__crate__api__source_rag__claim_source_for_ingestion_impl(port, ptr, rust_vec_len, data_len),
+38 => wire__crate__api__simple_rag__clear_all_documents_impl(port, ptr, rust_vec_len, data_len),
+39 => wire__crate__api__incremental_index__clear_buffer_impl(port, ptr, rust_vec_len, data_len),
+40 => wire__crate__api__hnsw_index__clear_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
+41 => wire__crate__api__source_rag__clear_source_chunks_impl(port, ptr, rust_vec_len, data_len),
+42 => wire__crate__api__db_pool__close_db_pool_impl(port, ptr, rust_vec_len, data_len),
+44 => wire__crate__api__compression_utils__compress_text_impl(port, ptr, rust_vec_len, data_len),
+45 => wire__crate__api__compression_utils__compress_text_simple_impl(port, ptr, rust_vec_len, data_len),
+46 => wire__crate__api__compression_utils__compression_options_default_impl(port, ptr, rust_vec_len, data_len),
+47 => wire__crate__api__migration_meta__count_chunks_needing_reembed_impl(port, ptr, rust_vec_len, data_len),
+50 => wire__crate__api__source_rag__delete_source_impl(port, ptr, rust_vec_len, data_len),
+51 => wire__crate__api__source_rag__delete_source_in_collection_impl(port, ptr, rust_vec_len, data_len),
+52 => wire__crate__api__source_rag__derive_context_budget_for_prompt_v2_impl(port, ptr, rust_vec_len, data_len),
+53 => wire__crate__api__migration_meta__detect_embedding_fingerprint_gate_impl(port, ptr, rust_vec_len, data_len),
+54 => wire__crate__api__hnsw_index__embedding_point_new_impl(port, ptr, rust_vec_len, data_len),
+55 => wire__crate__api__document_parser__extract_text_from_document_impl(port, ptr, rust_vec_len, data_len),
+56 => wire__crate__api__document_parser__extract_text_from_docx_impl(port, ptr, rust_vec_len, data_len),
+57 => wire__crate__api__document_parser__extract_text_from_file_impl(port, ptr, rust_vec_len, data_len),
+58 => wire__crate__api__document_parser__extract_text_from_pdf_impl(port, ptr, rust_vec_len, data_len),
+59 => wire__crate__api__document_parser__extract_text_from_utf8_impl(port, ptr, rust_vec_len, data_len),
+60 => wire__crate__api__migration_meta__finalize_embedding_reembed_impl(port, ptr, rust_vec_len, data_len),
+61 => wire__crate__api__source_rag__get_adjacent_chunks_impl(port, ptr, rust_vec_len, data_len),
+62 => wire__crate__api__source_rag__get_all_chunk_ids_and_contents_impl(port, ptr, rust_vec_len, data_len),
+63 => wire__crate__api__source_rag__get_all_chunk_ids_and_contents_in_collection_impl(port, ptr, rust_vec_len, data_len),
+64 => wire__crate__api__incremental_index__get_buffer_for_merge_impl(port, ptr, rust_vec_len, data_len),
+65 => wire__crate__api__incremental_index__get_buffer_stats_impl(port, ptr, rust_vec_len, data_len),
+66 => wire__crate__api__simple_rag__get_document_count_impl(port, ptr, rust_vec_len, data_len),
+67 => wire__crate__api__db_pool__get_pool_stats_impl(port, ptr, rust_vec_len, data_len),
+68 => wire__crate__api__source_rag__get_source_impl(port, ptr, rust_vec_len, data_len),
+69 => wire__crate__api__source_rag__get_source_chunk_count_impl(port, ptr, rust_vec_len, data_len),
+70 => wire__crate__api__source_rag__get_source_chunks_impl(port, ptr, rust_vec_len, data_len),
+71 => wire__crate__api__source_rag__get_source_stats_impl(port, ptr, rust_vec_len, data_len),
+72 => wire__crate__api__source_rag__get_source_stats_in_collection_impl(port, ptr, rust_vec_len, data_len),
+73 => wire__crate__api__source_rag__get_source_status_impl(port, ptr, rust_vec_len, data_len),
+76 => wire__crate__api__incremental_index__incremental_add_impl(port, ptr, rust_vec_len, data_len),
+77 => wire__crate__api__incremental_index__incremental_add_batch_impl(port, ptr, rust_vec_len, data_len),
+78 => wire__crate__api__incremental_index__incremental_remove_impl(port, ptr, rust_vec_len, data_len),
+79 => wire__crate__api__incremental_index__incremental_search_impl(port, ptr, rust_vec_len, data_len),
+81 => wire__crate__api__ingest_metrics__ingest_traffic_stats_legacy_text_traffic_total_impl(port, ptr, rust_vec_len, data_len),
+82 => wire__crate__api__ingest_metrics__ingest_traffic_stats_session_text_traffic_total_impl(port, ptr, rust_vec_len, data_len),
+83 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+84 => wire__crate__api__simple_rag__init_db_impl(port, ptr, rust_vec_len, data_len),
+85 => wire__crate__api__db_pool__init_db_pool_impl(port, ptr, rust_vec_len, data_len),
+87 => wire__crate__api__logger__init_logger_impl(port, ptr, rust_vec_len, data_len),
+88 => wire__crate__api__source_rag__init_source_db_impl(port, ptr, rust_vec_len, data_len),
+89 => wire__crate__api__tokenizer__init_tokenizer_impl(port, ptr, rust_vec_len, data_len),
+90 => wire__crate__api__bm25_search__is_bm25_index_loaded_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__source_rag__is_chunk_bm25_index_loaded_impl(port, ptr, rust_vec_len, data_len),
+92 => wire__crate__api__hnsw_index__is_hnsw_index_loaded_impl(port, ptr, rust_vec_len, data_len),
+93 => wire__crate__api__db_pool__is_pool_initialized_impl(port, ptr, rust_vec_len, data_len),
+94 => wire__crate__api__source_rag__list_chunks_needing_reembed_impl(port, ptr, rust_vec_len, data_len),
+95 => wire__crate__api__source_rag__list_sources_impl(port, ptr, rust_vec_len, data_len),
+96 => wire__crate__api__source_rag__list_sources_in_collection_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__source_rag__load_collection_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
+98 => wire__crate__api__hnsw_index__load_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
+100 => wire__crate__api__incremental_index__needs_merge_impl(port, ptr, rust_vec_len, data_len),
+103 => wire__crate__api__ingest_session__prepare_source_ingestion_impl(port, ptr, rust_vec_len, data_len),
+104 => wire__crate__api__ingest_session__prepare_source_ingestion_from_file_impl(port, ptr, rust_vec_len, data_len),
+105 => wire__crate__api__ingest_session__prepare_source_ingestion_from_utf8_impl(port, ptr, rust_vec_len, data_len),
+107 => wire__crate__api__query_metrics__query_content_read_stats_content_bytes_total_impl(port, ptr, rust_vec_len, data_len),
+108 => wire__crate__api__query_metrics__query_content_read_stats_hydration_content_bytes_total_impl(port, ptr, rust_vec_len, data_len),
+109 => wire__crate__api__query_metrics__query_content_read_stats_hydration_rows_total_impl(port, ptr, rust_vec_len, data_len),
+110 => wire__crate__api__query_metrics__query_content_read_stats_rows_total_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__migration_meta__read_migration_axes_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__simple_rag__rebuild_bm25_index_impl(port, ptr, rust_vec_len, data_len),
+113 => wire__crate__api__source_rag__rebuild_chunk_bm25_index_impl(port, ptr, rust_vec_len, data_len),
+114 => wire__crate__api__source_rag__rebuild_chunk_bm25_index_for_collection_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__source_rag__rebuild_chunk_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
+116 => wire__crate__api__source_rag__rebuild_chunk_hnsw_index_for_collection_impl(port, ptr, rust_vec_len, data_len),
+117 => wire__crate__api__simple_rag__rebuild_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
+120 => wire__crate__api__hybrid_search__rrf_config_default_impl(port, ptr, rust_vec_len, data_len),
+121 => wire__crate__api__source_rag__save_collection_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
+122 => wire__crate__api__hnsw_index__save_hnsw_index_impl(port, ptr, rust_vec_len, data_len),
+123 => wire__crate__api__source_rag__search_chunks_impl(port, ptr, rust_vec_len, data_len),
+124 => wire__crate__api__source_rag__search_chunks_in_collection_impl(port, ptr, rust_vec_len, data_len),
+125 => wire__crate__api__hnsw_index__search_hnsw_impl(port, ptr, rust_vec_len, data_len),
+126 => wire__crate__api__hnsw_index__search_hnsw_slice_impl(port, ptr, rust_vec_len, data_len),
+127 => wire__crate__api__hybrid_search__search_hybrid_impl(port, ptr, rust_vec_len, data_len),
+128 => wire__crate__api__hybrid_search__search_hybrid_simple_impl(port, ptr, rust_vec_len, data_len),
+129 => wire__crate__api__hybrid_search__search_hybrid_weighted_impl(port, ptr, rust_vec_len, data_len),
+130 => wire__crate__api__source_rag__search_meta_hybrid_impl(port, ptr, rust_vec_len, data_len),
+131 => wire__crate__api__simple_rag__search_similar_impl(port, ptr, rust_vec_len, data_len),
+134 => wire__crate__api__compression_utils__sentence_hash_impl(port, ptr, rust_vec_len, data_len),
+135 => wire__crate__api__compression_utils__should_compress_impl(port, ptr, rust_vec_len, data_len),
+136 => wire__crate__api__compression_utils__split_sentences_impl(port, ptr, rust_vec_len, data_len),
+139 => wire__crate__api__source_rag__update_chunk_embedding_impl(port, ptr, rust_vec_len, data_len),
+140 => wire__crate__api__source_rag__update_chunk_reembedded_impl(port, ptr, rust_vec_len, data_len),
+141 => wire__crate__api__source_rag__update_source_status_impl(port, ptr, rust_vec_len, data_len),
+142 => wire__crate__api__user_intent__user_intent_get_query_impl(port, ptr, rust_vec_len, data_len),
+143 => wire__crate__api__user_intent__user_intent_intent_type_impl(port, ptr, rust_vec_len, data_len),
+144 => wire__crate__api__migration_meta__write_embedding_fingerprint_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -6490,51 +6825,51 @@ fn pde_ffi_dispatcher_sync_impl(
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        31 => wire__crate__api__simple_rag__calculate_cosine_similarity_impl(
+        33 => wire__crate__api__simple_rag__calculate_cosine_similarity_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        35 => wire__crate__api__semantic_chunker__classify_chunk_impl(ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__logger__close_log_stream_impl(ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__tokenizer__count_tokens_impl(ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__tokenizer__decode_tokens_impl(ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__tokenizer__get_vocab_size_impl(ptr, rust_vec_len, data_len),
-        70 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        75 => {
+        37 => wire__crate__api__semantic_chunker__classify_chunk_impl(ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__logger__close_log_stream_impl(ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__tokenizer__count_tokens_impl(ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__tokenizer__decode_tokens_impl(ptr, rust_vec_len, data_len),
+        74 => wire__crate__api__tokenizer__get_vocab_size_impl(ptr, rust_vec_len, data_len),
+        75 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        80 => {
             wire__crate__api__ingest_metrics__ingest_traffic_stats_impl(ptr, rust_vec_len, data_len)
         }
-        81 => wire__crate__api__logger__init_log_stream_impl(ptr, rust_vec_len, data_len),
-        93 => wire__crate__api__semantic_chunker__markdown_chunk_impl(ptr, rust_vec_len, data_len),
-        95 => wire__crate__api__user_intent__parse_intent_impl(ptr, rust_vec_len, data_len),
-        96 => wire__crate__api__user_intent__parse_user_intent_impl(ptr, rust_vec_len, data_len),
-        100 => wire__crate__api__query_metrics__query_content_read_stats_impl(
+        86 => wire__crate__api__logger__init_log_stream_impl(ptr, rust_vec_len, data_len),
+        99 => wire__crate__api__semantic_chunker__markdown_chunk_impl(ptr, rust_vec_len, data_len),
+        101 => wire__crate__api__user_intent__parse_intent_impl(ptr, rust_vec_len, data_len),
+        102 => wire__crate__api__user_intent__parse_user_intent_impl(ptr, rust_vec_len, data_len),
+        106 => wire__crate__api__query_metrics__query_content_read_stats_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        112 => wire__crate__api__ingest_metrics__reset_ingest_traffic_stats_impl(
+        118 => wire__crate__api__ingest_metrics__reset_ingest_traffic_stats_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        113 => wire__crate__api__query_metrics__reset_query_content_read_stats_impl(
+        119 => wire__crate__api__query_metrics__reset_query_content_read_stats_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        126 => wire__crate__api__semantic_chunker__semantic_chunk_impl(ptr, rust_vec_len, data_len),
-        127 => wire__crate__api__semantic_chunker__semantic_chunk_with_overlap_impl(
+        132 => wire__crate__api__semantic_chunker__semantic_chunk_impl(ptr, rust_vec_len, data_len),
+        133 => wire__crate__api__semantic_chunker__semantic_chunk_with_overlap_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        131 => wire__crate__api__query_metrics__take_query_content_read_stats_impl(
+        137 => wire__crate__api__query_metrics__take_query_content_read_stats_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        132 => wire__crate__api__tokenizer__tokenize_impl(ptr, rust_vec_len, data_len),
+        138 => wire__crate__api__tokenizer__tokenize_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -6921,6 +7256,44 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::source_rag::ContextAssemblySt
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::migration_meta::EmbeddingFingerprintGate {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            crate::api::migration_meta::EmbeddingFingerprintGate::RequiresInitialBaseline => {
+                [0.into_dart()].into_dart()
+            }
+            crate::api::migration_meta::EmbeddingFingerprintGate::Ok => [1.into_dart()].into_dart(),
+            crate::api::migration_meta::EmbeddingFingerprintGate::Mismatch {
+                stored,
+                current,
+                remaining_chunks,
+                resume_in_progress,
+            } => [
+                2.into_dart(),
+                stored.into_into_dart().into_dart(),
+                current.into_into_dart().into_dart(),
+                remaining_chunks.into_into_dart().into_dart(),
+                resume_in_progress.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::migration_meta::EmbeddingFingerprintGate
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::migration_meta::EmbeddingFingerprintGate>
+    for crate::api::migration_meta::EmbeddingFingerprintGate
+{
+    fn into_into_dart(self) -> crate::api::migration_meta::EmbeddingFingerprintGate {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::hnsw_index::EmbeddingPoint {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -7115,6 +7488,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::migration_meta::MigrationAxes
             self.hnsw_format_version.into_into_dart().into_dart(),
             self.bm25_stats_version.into_into_dart().into_dart(),
             self.embedding_fingerprint.into_into_dart().into_dart(),
+            self.embedding_fingerprint_pending
+                .into_into_dart()
+                .into_dart(),
             self.last_engine_version.into_into_dart().into_dart(),
         ]
         .into_dart()
@@ -7280,8 +7656,15 @@ impl flutter_rust_bridge::IntoDart for crate::api::error::RagError {
                 field2.into_into_dart().into_dart(),
             ]
             .into_dart(),
+            crate::api::error::RagError::EmbeddingFingerprintMismatch(field0, field1, field2) => [
+                8.into_dart(),
+                field0.into_into_dart().into_dart(),
+                field1.into_into_dart().into_dart(),
+                field2.into_into_dart().into_dart(),
+            ]
+            .into_dart(),
             crate::api::error::RagError::Unknown(field0) => {
-                [8.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+                [9.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
             _ => {
                 unimplemented!("");
@@ -7776,6 +8159,35 @@ impl SseEncode for crate::api::source_rag::ContextAssemblyStrategy {
     }
 }
 
+impl SseEncode for crate::api::migration_meta::EmbeddingFingerprintGate {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        match self {
+            crate::api::migration_meta::EmbeddingFingerprintGate::RequiresInitialBaseline => {
+                <i32>::sse_encode(0, serializer);
+            }
+            crate::api::migration_meta::EmbeddingFingerprintGate::Ok => {
+                <i32>::sse_encode(1, serializer);
+            }
+            crate::api::migration_meta::EmbeddingFingerprintGate::Mismatch {
+                stored,
+                current,
+                remaining_chunks,
+                resume_in_progress,
+            } => {
+                <i32>::sse_encode(2, serializer);
+                <String>::sse_encode(stored, serializer);
+                <String>::sse_encode(current, serializer);
+                <i64>::sse_encode(remaining_chunks, serializer);
+                <bool>::sse_encode(resume_in_progress, serializer);
+            }
+            _ => {
+                unimplemented!("");
+            }
+        }
+    }
+}
+
 impl SseEncode for crate::api::hnsw_index::EmbeddingPoint {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -8105,6 +8517,7 @@ impl SseEncode for crate::api::migration_meta::MigrationAxes {
         <i64>::sse_encode(self.hnsw_format_version, serializer);
         <i64>::sse_encode(self.bm25_stats_version, serializer);
         <String>::sse_encode(self.embedding_fingerprint, serializer);
+        <String>::sse_encode(self.embedding_fingerprint_pending, serializer);
         <String>::sse_encode(self.last_engine_version, serializer);
     }
 }
@@ -8310,8 +8723,14 @@ impl SseEncode for crate::api::error::RagError {
                 <i64>::sse_encode(field1, serializer);
                 <i64>::sse_encode(field2, serializer);
             }
-            crate::api::error::RagError::Unknown(field0) => {
+            crate::api::error::RagError::EmbeddingFingerprintMismatch(field0, field1, field2) => {
                 <i32>::sse_encode(8, serializer);
+                <String>::sse_encode(field0, serializer);
+                <String>::sse_encode(field1, serializer);
+                <i64>::sse_encode(field2, serializer);
+            }
+            crate::api::error::RagError::Unknown(field0) => {
+                <i32>::sse_encode(9, serializer);
                 <String>::sse_encode(field0, serializer);
             }
             _ => {

--- a/test/native/embedding_fingerprint_gate_test.dart
+++ b/test/native/embedding_fingerprint_gate_test.dart
@@ -1,0 +1,333 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_rag_engine/src/rust/api/db_pool.dart';
+import 'package:mobile_rag_engine/src/rust/api/error.dart';
+import 'package:mobile_rag_engine/src/rust/api/migration_meta.dart';
+import 'package:mobile_rag_engine/src/rust/api/source_rag.dart' as source_rag;
+import 'package:mobile_rag_engine/src/rust/frb_generated.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+Future<void> _ensureRustLoaded() async {
+  if (!RustLib.instance.initialized) {
+    await RustLib.init();
+  }
+}
+
+Future<Directory> _freshDir() =>
+    Directory.systemTemp.createTemp('mobile_rag_fingerprint_gate_');
+
+/// Insert a chunk row directly, bypassing the ingest pipeline.
+///
+/// The test needs control over the chunk's `embedding_fingerprint` tag and
+/// the embedding bytes don't matter for the gate flow, so a raw INSERT keeps
+/// the test focused on the migration_meta surface under exercise.
+void _seedChunk({
+  required Database db,
+  required int sourceId,
+  required int chunkIndex,
+  required String content,
+  required String fingerprint,
+}) {
+  final fakeEmbedding = Uint8List(4 * 8); // 8 floats, zeroed.
+  db.execute(
+    "INSERT INTO chunks (source_id, collection_id, chunk_index, content, "
+    "start_pos, end_pos, chunk_type, embedding, embedding_fingerprint) "
+    "VALUES (?, '__default__', ?, ?, 0, ?, 'general', ?, ?)",
+    [sourceId, chunkIndex, content, content.length, fakeEmbedding, fingerprint],
+  );
+}
+
+void _seedSource({required Database db, required int id, required String content}) {
+  db.execute(
+    "INSERT INTO sources (id, content, content_hash, status, collection_id) "
+    "VALUES (?, ?, ?, 'completed', '__default__')",
+    [id, content, 'hash-$id'],
+  );
+}
+
+int _chunkCountInDb(String dbPath) {
+  final db = sqlite3.open(dbPath);
+  try {
+    final result = db.select('SELECT COUNT(*) AS n FROM chunks');
+    return result.first['n'] as int;
+  } finally {
+    db.dispose();
+  }
+}
+
+void main() {
+  setUpAll(() async {
+    await _ensureRustLoaded();
+  });
+
+  tearDown(() async {
+    await closeDbPool();
+  });
+
+  test(
+    'model swap surfaces EmbeddingFingerprintGate.mismatch with remaining count',
+    () async {
+      final dir = await _freshDir();
+      try {
+        final dbPath = '${dir.path}/model_swap.sqlite';
+        await initDbPool(dbPath: dbPath, maxSize: 2);
+        await source_rag.initSourceDb();
+
+        // Establish baseline fingerprint "modelA|384|f32" and tag chunks.
+        await writeEmbeddingFingerprint(fingerprint: 'modelA|384|f32');
+        final seed = sqlite3.open(dbPath);
+        try {
+          _seedSource(db: seed, id: 1, content: 'doc-1');
+          _seedChunk(
+            db: seed,
+            sourceId: 1,
+            chunkIndex: 0,
+            content: 'chunk-1',
+            fingerprint: 'modelA|384|f32',
+          );
+          _seedChunk(
+            db: seed,
+            sourceId: 1,
+            chunkIndex: 1,
+            content: 'chunk-2',
+            fingerprint: 'modelA|384|f32',
+          );
+        } finally {
+          seed.dispose();
+        }
+
+        final gate = await detectEmbeddingFingerprintGate(
+          currentFingerprint: 'modelB|384|f32',
+        );
+        switch (gate) {
+          case EmbeddingFingerprintGate_Mismatch(
+              :final stored,
+              :final current,
+              :final remainingChunks,
+              :final resumeInProgress,
+            ):
+            expect(stored, 'modelA|384|f32');
+            expect(current, 'modelB|384|f32');
+            expect(remainingChunks, 2);
+            expect(resumeInProgress, isFalse,
+                reason: 'no reembed has been started yet');
+          default:
+            fail('Expected Mismatch, got $gate');
+        }
+      } finally {
+        await dir.delete(recursive: true);
+      }
+    },
+  );
+
+  test(
+    'reembed resumes across simulated app restart and finalize commits',
+    () async {
+      final dir = await _freshDir();
+      try {
+        final dbPath = '${dir.path}/resume.sqlite';
+        await initDbPool(dbPath: dbPath, maxSize: 2);
+        await source_rag.initSourceDb();
+        await writeEmbeddingFingerprint(fingerprint: 'old');
+
+        final seed = sqlite3.open(dbPath);
+        try {
+          _seedSource(db: seed, id: 1, content: 'doc-1');
+          for (var i = 0; i < 4; i++) {
+            _seedChunk(
+              db: seed,
+              sourceId: 1,
+              chunkIndex: i,
+              content: 'chunk-$i',
+              fingerprint: 'old',
+            );
+          }
+        } finally {
+          seed.dispose();
+        }
+
+        // Start the reembed and finish half of the chunks.
+        final remainingAtStart = await beginEmbeddingReembed(
+          targetFingerprint: 'new',
+        );
+        expect(remainingAtStart, 4);
+        final firstBatch = await source_rag.listChunksNeedingReembed(
+          targetFingerprint: 'new',
+          limit: 2,
+        );
+        expect(firstBatch.length, 2);
+        for (final chunk in firstBatch) {
+          await source_rag.updateChunkReembedded(
+            chunkId: chunk.chunkId,
+            embedding: Float32List.fromList(List<double>.filled(4, 0.1)),
+            targetFingerprint: 'new',
+          );
+        }
+        expect(
+          await countChunksNeedingReembed(targetFingerprint: 'new'),
+          2,
+          reason: 'half-done state must persist',
+        );
+
+        // Simulate an app restart — close the pool, re-open the same file.
+        await closeDbPool();
+        await initDbPool(dbPath: dbPath, maxSize: 2);
+
+        // Gate detection should now signal resume_in_progress = true.
+        final gate = await detectEmbeddingFingerprintGate(
+          currentFingerprint: 'new',
+        );
+        switch (gate) {
+          case EmbeddingFingerprintGate_Mismatch(
+              :final remainingChunks,
+              :final resumeInProgress,
+            ):
+            expect(remainingChunks, 2);
+            expect(resumeInProgress, isTrue,
+                reason: 'pending axis still records the in-flight target');
+          default:
+            fail('Expected Mismatch with resume, got $gate');
+        }
+
+        // Resume — finalize once every chunk is tagged.
+        final secondBatch = await source_rag.listChunksNeedingReembed(
+          targetFingerprint: 'new',
+          limit: 10,
+        );
+        expect(secondBatch.length, 2);
+        for (final chunk in secondBatch) {
+          await source_rag.updateChunkReembedded(
+            chunkId: chunk.chunkId,
+            embedding: Float32List.fromList(List<double>.filled(4, 0.2)),
+            targetFingerprint: 'new',
+          );
+        }
+
+        await finalizeEmbeddingReembed(targetFingerprint: 'new');
+
+        final axes = await readMigrationAxes();
+        expect(axes.embeddingFingerprint, 'new');
+        expect(axes.embeddingFingerprintPending, '',
+            reason: 'pending must clear on finalize');
+
+        final closedGate = await detectEmbeddingFingerprintGate(
+          currentFingerprint: 'new',
+        );
+        expect(closedGate, isA<EmbeddingFingerprintGate_Ok>());
+      } finally {
+        await dir.delete(recursive: true);
+      }
+    },
+  );
+
+  test(
+    'clearAndRestart refuses to delete embeddings without the confirmation token',
+    () async {
+      final dir = await _freshDir();
+      try {
+        final dbPath = '${dir.path}/clear_guard.sqlite';
+        await initDbPool(dbPath: dbPath, maxSize: 2);
+        await source_rag.initSourceDb();
+        await writeEmbeddingFingerprint(fingerprint: 'old');
+
+        final seed = sqlite3.open(dbPath);
+        try {
+          _seedSource(db: seed, id: 1, content: 'doc-1');
+          _seedChunk(
+            db: seed,
+            sourceId: 1,
+            chunkIndex: 0,
+            content: 'keep-me',
+            fingerprint: 'old',
+          );
+        } finally {
+          seed.dispose();
+        }
+
+        await expectLater(
+          acknowledgeAndClearEmbeddings(
+            confirmation: 'totally not the token',
+            newFingerprint: 'new',
+          ),
+          throwsA(
+            isA<RagError_InvalidInput>().having(
+              (e) => e.field0,
+              'message',
+              contains('confirmation'),
+            ),
+          ),
+        );
+
+        expect(_chunkCountInDb(dbPath), 1,
+            reason: 'chunk must survive a refused clear');
+        final axes = await readMigrationAxes();
+        expect(axes.embeddingFingerprint, 'old',
+            reason: 'axis must not rotate without consent');
+      } finally {
+        await dir.delete(recursive: true);
+      }
+    },
+  );
+
+  test(
+    'clearAndRestart with confirmation drops chunks and rotates the fingerprint',
+    () async {
+      final dir = await _freshDir();
+      try {
+        final dbPath = '${dir.path}/clear_apply.sqlite';
+        await initDbPool(dbPath: dbPath, maxSize: 2);
+        await source_rag.initSourceDb();
+        await writeEmbeddingFingerprint(fingerprint: 'old');
+
+        final seed = sqlite3.open(dbPath);
+        try {
+          _seedSource(db: seed, id: 1, content: 'doc-1');
+          _seedSource(db: seed, id: 2, content: 'doc-2');
+          _seedChunk(
+            db: seed,
+            sourceId: 1,
+            chunkIndex: 0,
+            content: 'c1',
+            fingerprint: 'old',
+          );
+          _seedChunk(
+            db: seed,
+            sourceId: 2,
+            chunkIndex: 0,
+            content: 'c2',
+            fingerprint: 'old',
+          );
+        } finally {
+          seed.dispose();
+        }
+
+        final deleted = await acknowledgeAndClearEmbeddings(
+          confirmation:
+              'I_UNDERSTAND_THIS_DELETES_ALL_ON_DEVICE_EMBEDDINGS',
+          newFingerprint: 'new',
+        );
+        expect(deleted, 2);
+        expect(_chunkCountInDb(dbPath), 0);
+
+        // Sources are intentionally preserved so the host app can re-ingest.
+        final sourceCount = sqlite3.open(dbPath);
+        try {
+          final result =
+              sourceCount.select('SELECT COUNT(*) AS n FROM sources');
+          expect(result.first['n'], 2,
+              reason: 'sources must survive clearAndRestart');
+        } finally {
+          sourceCount.dispose();
+        }
+
+        final axes = await readMigrationAxes();
+        expect(axes.embeddingFingerprint, 'new');
+        expect(axes.embeddingFingerprintPending, '');
+      } finally {
+        await dir.delete(recursive: true);
+      }
+    },
+  );
+}

--- a/test/native/smart_error_test.dart
+++ b/test/native/smart_error_test.dart
@@ -41,6 +41,9 @@ void main() {
           unsupportedMigrationVersion: (axis, stored, supported) => fail(
             'Unexpected UnsupportedMigrationVersion($axis, $stored, $supported)',
           ),
+          embeddingFingerprintMismatch: (stored, current, remaining) => fail(
+            'Unexpected EmbeddingFingerprintMismatch($stored, $current, $remaining)',
+          ),
           unknown: (msg) => fail('Unexpected Unknown error: $msg'),
         );
       }


### PR DESCRIPTION
## Summary
- Probes the loaded embedding model once during `initialize()`, composes a `{modelBasename}|{dim}|{quant}` fingerprint, and routes it through the new `EmbeddingFingerprintGate` (`RequiresInitialBaseline` / `Ok` / `Mismatch`).
- On `Mismatch`, sets a Dart-side lock so every `addDocument*`, `search*`, and `rebuildIndex` entry point throws `RagError.embeddingFingerprintMismatch(stored, current, remaining)` until the host app resolves it.
- Adds two recovery paths on `MobileRag.instance`:
  - `reembedAll(progress:)` — resumable across app restarts; per-chunk `embedding_fingerprint` tag plus the new `embedding_fingerprint_pending` axis let an interrupted run pick up exactly where it stopped, then finalize atomically.
  - `clearAndRestart(confirm:)` — requires the typed `ClearAndRestartConfirmation.iUnderstandThisDeletesAllOnDeviceEmbeddings` sentinel AND the Rust-side `EMBEDDING_CLEAR_CONFIRMATION` token before any chunk is deleted; sources are preserved so they can be re-ingested.

## Axis values (before / after)
| Axis | Before this PR | After this PR |
|---|---|---|
| `sql_schema_version` | `1` (new) / `0` (upgrade) | unchanged — column add is absorbed by the existing in-place ALTER pattern |
| `hnsw_format_version` | `1` (new) / `0` (upgrade) | unchanged |
| `bm25_stats_version` | `1` (new) / `0` (upgrade) | unchanged |
| `embedding_fingerprint` | `\"\"` (sentinel) | `\"{modelBasename}\|{dim}\|f32\"` written on first boot |
| **`embedding_fingerprint_pending`** | **(did not exist)** | **new axis. Empty by default; carries the target fingerprint while a reembed is in flight (sticky across reboots ⇒ resumable).** |
| `last_engine_version` | `CARGO_PKG_VERSION` (refresh-only) | unchanged |

P0-1 installs back-fill `embedding_fingerprint_pending` to empty silently on their first boot under this build (covered by `p0_1_install_backfills_pending_axis`).

## Migration decisions (Apply / Rebuild / Invalidate)
- **Apply (auto):** create the new axis row, ALTER ADD `chunks.embedding_fingerprint TEXT`, and on the first boot under a fresh build write `embedding_fingerprint` + back-fill every chunk's tag in a single transaction.
- **Rebuild + host callback:** `reembedAll(progress:)` re-embeds each chunk via the loaded model, updates `(embedding, embedding_fingerprint)` atomically per chunk, finalizes by promoting `embedding_fingerprint = target` and clearing pending, then forces an HNSW rebuild. `onProgress(RagReembedProgress)` fires per chunk for host UI.
- **Invalidate (explicit confirm only):** `clearAndRestart(confirm:)` drops the chunks table and rotates the fingerprint axes; the Rust side refuses any other token, so passive flows can never reach the destructive branch.

While locked, `listSources`, `getStats`, `getSource*`, and hydration APIs are intentionally NOT gated so a host app can still render existing documents while prompting for resolution.

## Tests
- Rust unit (`cargo test --lib -- --test-threads=1`): **123 passed / 0 failed / 1 ignored**. New: `p0_1_install_backfills_pending_axis`, `gate_requires_baseline_on_empty_fingerprint`, `gate_ok_when_stored_matches_current`, `gate_mismatch_reports_remaining_chunks`, `reembed_lifecycle_progresses_and_finalizes`, `clear_requires_confirmation_token`, `clear_with_confirmation_wipes_chunks_and_rotates_axis`.
- Dart native (`flutter test test/native/`): **10/10 passed** (existing 6 + 4 new).
- New `test/native/embedding_fingerprint_gate_test.dart` exercises: model swap → \`Mismatch\` with remaining count; **kill mid-stream**: begin → half-tag → close pool → re-open → `resume_in_progress == true` → finish → finalize; refused clear preserves chunks + axis; confirmed clear deletes chunks, preserves sources, rotates axis.
- `flutter analyze`: clean.

## Not covered by automation (intentional gaps)
- End-to-end \`MobileRag.search()\`/\`addDocument()\` rejection while locked is exercised only via the `_ensureEmbeddingFingerprintUnlocked()` helper unit-style — the public-API throw needs host-app smoke (real ONNX model load required).
- Concurrent `reembedAll()` + `clearAndRestart()` is not race-free in Dart; host app must serialize.
- `reembedAll()` forces a synchronous HNSW rebuild on completion; on large corpora this can exceed the 'seconds-scale cold-start' budget. Host apps should call from a background isolate or set `deferIndexWarmup`.

## Test plan
- [x] `cargo test --lib -- --test-threads=1`
- [x] `flutter analyze`
- [x] `flutter test test/native/embedding_fingerprint_gate_test.dart`
- [x] `flutter test test/native/migration_meta_test.dart`
- [x] `flutter test test/native/smart_error_test.dart`
- [ ] Manual device smoke: launch host app with model A → ingest a few docs → swap to model B (same dim, different file name) → reboot → confirm `embeddingFingerprintLock` is non-null and `search()` throws `RagError.embeddingFingerprintMismatch` → run `reembedAll()` with progress callback → confirm lock clears and search returns results
- [ ] Manual device smoke for `clearAndRestart(confirm:)`: same setup but resolve via clear instead → confirm chunks table empties and source rows survive

## Notes for reviewers
- `pubspec.yaml` already gained `sqlite3` under `dev_dependencies` in P0-1 — no further pubspec changes here.
- No public API removals; new public surface: `MobileRag.embeddingFingerprintLock`, `reembedAll`, `clearAndRestart`, `reembedRemaining`, `currentEmbeddingFingerprint`, `RagReembedProgress`, `ClearAndRestartConfirmation`, `RagEmbeddingFingerprintLock`, `RagError.embeddingFingerprintMismatch`, and the regenerated `MigrationAxes.embeddingFingerprintPending` field.