### PR TITLE
Feats/release 0.18.5 pdf quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.18.5
+* **PDF extraction quality**:
+  - Bumped dependency constraint to `rag_engine_flutter: ^0.18.3` so consumers receive the native PDF extraction improvements.
+  - Preserves paragraph boundaries during PDF extraction, improving downstream semantic chunking for long documents.
+  - Recovers around per-page PDF extraction failures instead of failing the entire document when one page is malformed.
+  - Cleans dense adjacent double-rendered text artifacts while keeping conservative false-positive guards for natural repetitions and English words.
+  - Surfaces scanned/image-only or effectively empty PDFs as extraction errors instead of silently indexing unsearchable 0-chunk sources.
+
 ## 0.18.4
 * **Retrieval hot path**:
   - Scoped source/metadata hybrid searches now preserve BM25 ranks through the active collection BM25 term index instead of reading and tokenizing every scoped chunk body at query time.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -206,7 +206,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.18.4"
+    version: "0.18.5"
   onnxruntime:
     dependency: transitive
     description:
@@ -293,7 +293,7 @@ packages:
       path: "../rust_builder"
       relative: true
     source: path
-    version: "0.18.2"
+    version: "0.18.3"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -479,10 +479,10 @@ packages:
     dependency: "direct main"
     description:
       name: rag_engine_flutter
-      sha256: f499d25ced5a81d2f00024a442d32520698cd61b17b15b74661080f40b3088b0
+      sha256: e4e4481242648807058b51bad34e891d9593cf0f720e5f77f2c26deef0d4b23a
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.2"
+    version: "0.18.3"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_rag_engine
 description: A high-performance, on-device RAG (Retrieval-Augmented Generation) engine for Flutter. Run semantic search completely offline on iOS, Android, and macOS with HNSW vector indexing.
-version: 0.18.4
+version: 0.18.5
 homepage: https://github.com/dev07060/mobile_rag_engine
 repository: https://github.com/dev07060/mobile_rag_engine
 issue_tracker: https://github.com/dev07060/mobile_rag_engine/issues
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_rust_bridge: ^2.11.1
-  rag_engine_flutter: ^0.18.2
+  rag_engine_flutter: ^0.18.3
   path_provider: ^2.1.5
   onnxruntime: ^1.4.1
   freezed_annotation: ^3.1.0

--- a/rust_builder/CHANGELOG.md
+++ b/rust_builder/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.18.3
+* **PDF extraction quality**:
+  - Preserved paragraph boundaries while normalizing PDF text so downstream chunking can split on semantic breaks instead of one long flattened body.
+  - Added per-page PDF extraction with per-page fallback so a single malformed page no longer aborts the whole document.
+  - Deduplicated dense adjacent double-rendered text artifacts seen in Korean PDFs while guarding natural repetitions and English words from false-positive rewrites.
+  - Surfaced scanned/image-only or effectively empty PDF extraction as an error instead of silently indexing an unsearchable 0-chunk source.
+
 ## 0.18.2
 * **Scoped BM25 search**:
   - Added scoped BM25 ranking over the existing in-memory inverted index, restricted by the scoped chunk ids collected during exact vector scan.

--- a/rust_builder/pubspec.yaml
+++ b/rust_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: rag_engine_flutter
 description: >
   Native Rust FFI plugin for mobile_rag_engine. Provides high-performance
   tokenization and HNSW vector indexing for on-device RAG.
-version: 0.18.2
+version: 0.18.3
 homepage: https://github.com/dev07060/mobile_rag_engine
 repository: https://github.com/dev07060/mobile_rag_engine
 issue_tracker: https://github.com/dev07060/mobile_rag_engine/issues


### PR DESCRIPTION
PDF extraction quality:
- Bumped dependency constraint to rag_engine_flutter: ^0.18.3 so consumers receive the native PDF extraction improvements.
- Preserves paragraph boundaries during PDF extraction, improving downstream semantic chunking for long documents.
- Recovers around per-page PDF extraction failures instead of failing the entire document when one page is malformed.
- Cleans dense adjacent double-rendered text artifacts while keeping conservative false-positive guards for natural repetitions and English words.
- Surfaces scanned/image-only or effectively empty PDFs as extraction errors instead of silently indexing unsearchable 0-chunk sources.