### PR TITLE
refactor(ocr): distinguish scanned PDFs from page-failures, unify detection

### DIFF
--- a/example/lib/services/rag_controller.dart
+++ b/example/lib/services/rag_controller.dart
@@ -288,15 +288,26 @@ class RagController extends ChangeNotifier {
         );
       }
     } catch (e, st) {
-      if (DocumentParser.isOcrRequiredPdfExtractionError(e)) {
-        _updateState(
-          DocumentParser.scannedPdfOcrRequiredMessage,
-          newIsLoading: false,
-        );
-        return;
-      }
+      if (_showOcrGuidanceIfRequired(e)) return;
       _updateState("❌ Import error: $e\n$st", newIsLoading: false);
     }
+  }
+
+  /// If [error] is a recognized OCR-required PDF failure, surface the
+  /// user-facing OCR guidance and return true so the caller can stop.
+  ///
+  /// Detection is content-based (the Rust error text), not extension-based, so
+  /// a scanned PDF is handled identically on every import path — including when
+  /// the picked file is mis-named.
+  bool _showOcrGuidanceIfRequired(Object error) {
+    if (!DocumentParser.isOcrRequiredPdfExtractionError(error)) {
+      return false;
+    }
+    _updateState(
+      DocumentParser.userMessageForExtractionError(error),
+      newIsLoading: false,
+    );
+    return true;
   }
 
   String _extensionFor(PlatformFile file, String filePath) {
@@ -427,14 +438,7 @@ class RagController extends ChangeNotifier {
       );
       return _PickedImportResult(addResult: addResult);
     } on RagError catch (e) {
-      if (extension == 'pdf' &&
-          DocumentParser.isOcrRequiredPdfExtractionError(e)) {
-        _updateState(
-          DocumentParser.scannedPdfOcrRequiredMessage,
-          newIsLoading: false,
-        );
-        return null;
-      }
+      if (_showOcrGuidanceIfRequired(e)) return null;
       debugPrint('File path ingest failed, falling back: $e');
     }
 
@@ -457,14 +461,7 @@ class RagController extends ChangeNotifier {
     try {
       extractedText = await DocumentParser.parse(bytes);
     } catch (e) {
-      if (extension == 'pdf' &&
-          DocumentParser.isOcrRequiredPdfExtractionError(e)) {
-        _updateState(
-          DocumentParser.scannedPdfOcrRequiredMessage,
-          newIsLoading: false,
-        );
-        return null;
-      }
+      if (_showOcrGuidanceIfRequired(e)) return null;
       rethrow;
     }
     if (extractedText.isEmpty) {

--- a/lib/services/document_parser.dart
+++ b/lib/services/document_parser.dart
@@ -14,15 +14,20 @@ class DocumentParser {
       '이 PDF는 텍스트를 추출할 수 없습니다.\n'
       '스캔본 또는 이미지 기반 PDF일 수 있어 OCR 처리가 필요합니다.';
 
-  /// Returns true when a PDF extraction error indicates effectively empty text.
+  /// Returns true when a PDF extraction error indicates a scanned/image-only
+  /// document — the kind OCR can recover.
   ///
-  /// The Rust parser intentionally returns an error for scanned/image-only PDFs
-  /// so host apps can show an OCR-specific message instead of indexing an
-  /// unsearchable document.
+  /// The Rust parser surfaces a below-threshold error for two distinct cases
+  /// that share the same `"… fewer than N non-whitespace …"` prefix:
+  ///   * scanned/image-only PDFs with no text layer — OCR helps;
+  ///   * PDFs whose pages failed to extract (corrupt/unsupported content) —
+  ///     OCR will *not* help.
+  /// Only the first should drive the OCR-required message, so this keys on the
+  /// scanned-specific marker rather than the shared prefix.
   static bool isOcrRequiredPdfExtractionError(Object error) {
     final message = error.toString();
     return message.contains('PDF text extraction returned fewer than') &&
-        message.contains('non-whitespace');
+        message.contains('scanned/image-only');
   }
 
   /// Convert known extraction failures into user-facing copy.

--- a/test/unit/document_parser_error_helper_test.dart
+++ b/test/unit/document_parser_error_helper_test.dart
@@ -3,7 +3,7 @@ import 'package:mobile_rag_engine/mobile_rag_engine.dart';
 
 void main() {
   group('DocumentParser extraction error helpers', () {
-    test('maps effectively empty PDF extraction errors to OCR guidance', () {
+    test('classifies scanned/image-only PDF errors as OCR-required', () {
       const error =
           'Document extraction failed for "/tmp/scan.pdf": PDF text extraction '
           'returned fewer than 16 non-whitespace characters; PDF may be '
@@ -19,6 +19,21 @@ void main() {
         '이 PDF는 텍스트를 추출할 수 없습니다.\n'
         '스캔본 또는 이미지 기반 PDF일 수 있어 OCR 처리가 필요합니다.',
       );
+    });
+
+    test('does NOT classify page-extraction-failure PDFs as OCR-required', () {
+      // Same below-threshold error family, but here individual pages failed to
+      // extract (corrupt/unsupported content), which OCR cannot fix. This
+      // message shares the "fewer than ... non-whitespace" prefix with the
+      // scanned case, so the classifier must key on the scanned-specific
+      // marker, not the shared prefix.
+      const error =
+          'Document extraction failed for "/tmp/broken.pdf": PDF text '
+          'extraction returned fewer than 16 non-whitespace characters; '
+          '3 of 5 page(s) failed to extract (pages: [1, 2, 3])';
+
+      expect(DocumentParser.isOcrRequiredPdfExtractionError(error), isFalse);
+      expect(DocumentParser.userMessageForExtractionError(error), error);
     });
 
     test('leaves unrelated extraction errors unchanged', () {


### PR DESCRIPTION
## Summary
Cleanup of the PDF OCR-required detection added in #60, addressing items surfaced by the code review.

- **Correctness:** `DocumentParser.isOcrRequiredPdfExtractionError` now keys on the scanned-specific `scanned/image-only` marker instead of the prefix shared by the parser's two below-threshold errors. A PDF whose pages *failed to extract* (corrupt/unsupported content, which OCR cannot fix) is no longer mislabeled as "needs OCR".
- **Consistency:** the three duplicated OCR-handling blocks in the example `RagController` — which had already drifted (the outer catch lacked the `extension == 'pdf'` guard the other two carried) — collapse into one `_showOcrGuidanceIfRequired` helper. The extension guard is dropped: detection is content-based (the Rust error text), so a scanned PDF is handled identically on every import path, including when the picked file is mis-named.
- **Dead code:** the previously-unused `userMessageForExtractionError` is now the single source of the user-facing copy the helper surfaces.

## Test
- New regression test pins page-extraction-failure errors as non-OCR (`test/unit/document_parser_error_helper_test.dart`).
- `flutter test test/unit` green (58 tests); `flutter analyze` clean on the package and the example app.

## Notes
Based on current `main` (post-#60); single commit.