### PR TITLE
ci(vector_math): 출시 faer 백엔드 빌드+테스트 (N2, LOC-60)

### DIFF
--- a/docs/perf/vector-math-refactor/PR2.md
+++ b/docs/perf/vector-math-refactor/PR2.md
@@ -1,0 +1,37 @@
+# PR2 — 출시 faer 백엔드 CI 커버리지 (N2) [faer 유지]
+
+- 브랜치: `feat/loc-60-faer-ci-coverage`
+- Linear: [LOC-60](https://linear.app/loceract/issue/LOC-60)
+- 상태: 🟦 진행 (PR 열림, CI green 대기)
+
+## 재설계 배경
+PR1([PR1.md](PR1.md)) 벤치가 원안("faer 제거 → fused 통일")의 전제를 반증 — faer가 2–8× 빠름.
+따라서 faer를 **유지**하고, 대신 PR1이 드러낸 **N2 갭**(출시되는 faer+quant 백엔드가 CI에서 빌드/테스트
+0회)을 닫는 것으로 PR2를 재설계.
+
+## 스코프 (무엇을/왜)
+[scripts/test_ci.sh](../../../scripts/test_ci.sh) `native` 잡 확장:
+1. **faer-백엔드 vector_math 테스트** — `cargo test --lib --features vector_faer vector_math -- --test-threads=1`,
+   PDF 스모크와 동일한 **fail-closed**(≥1 test 통과 요구). PR1의 faer↔fused 패리티 테스트가 여기서 실행됨.
+2. **출시 feature 조합 릴리스 빌드** — `cargo build --release --features vector_faer,vector_quant_i8`
+   (기존 default-feature 빌드를 출시 조합으로 교체 → 실제 출시 백엔드를 컴파일 게이트).
+3. [vector_math.rs](../../../rust_builder/rust/src/api/vector_math.rs) 모듈 doc 정정 — "allocation-free" 문구를
+   faer 백엔드 현실(per-call 할당, but SIMD로 2–8× 빠름)에 맞게 수정.
+
+## 결과 (Before → After)
+- N2 갭: **닫힘** — 출시 faer+quant 경로가 CI에서 빌드 + 테스트됨.
+- 로컬 검증: `bash -n` OK; faer 테스트 4개(패리티 포함) green, fail-closed PASS; `cargo build --release
+  --features vector_faer,vector_quant_i8` 성공(50s, 기존 dead_code 경고만).
+- CI: (PR #__ green 후 갱신)
+
+## 받은 피드백 (리뷰)
+- (PR 리뷰 후 갱신)
+
+## 리스크 / 롤백
+- CI native 잡 시간 증가(faer 2회 컴파일: test+release 프로파일). 게이트 가치 대비 수용.
+- 롤백: test_ci.sh 변경 revert. 동작 코드 변경 없음(테스트/스크립트/주석만).
+- R8(공유 SQLite 플레이크): faer 테스트도 `--test-threads=1` 고정으로 회피.
+
+## 결정 로그
+- N1(무할당화)은 PR1에서 throughput 무의미 확인 → PR2 범위 제외(추후 선택적 마이크로옵트).
+- R9(전제 반증) 해소: faer 유지 확정, N2로 전환.

--- a/docs/perf/vector-math-refactor/README.md
+++ b/docs/perf/vector-math-refactor/README.md
@@ -14,8 +14,8 @@
 - ~~가장 큰 실효 조치: faer 제거 → fused 커널 통일~~ → **⚠️ PR1 실측으로 반증됨 (아래)**.
 
 > **⚠️ 2026-05-30 PR1 업데이트:** 벤치 결과 **faer가 fused보다 2–8× 빠름**(exact_scan 2.8×). f32 리덕션이
-> 자동 벡터화되지 않아 fused가 스칼라로 도는 반면 faer는 SIMD gemm 사용. **PR2 “faer 제거” 전제는 반증** →
-> faer 유지 + N2(CI 커버리지)[+선택 N1 무할당화]로 피벗 검토 중. 상세 [PR1.md](PR1.md).
+> 자동 벡터화되지 않아 fused가 스칼라로 도는 반면 faer는 SIMD gemm 사용. **PR2 “faer 제거” 전제는 반증.**
+> **결정: faer 유지.** PR2는 N2(출시 faer 백엔드 CI 커버리지)로 전환(진행). 상세 [PR1.md](PR1.md) · [PR2.md](PR2.md).
 
 ## PR 분할 / 상태
 
@@ -25,7 +25,7 @@
 |----|------|------|--------|------|--------|------|
 | PR0 | 작업 저널 스캐폴드 | 보존 체계 | 없음(문서) | — | [LOC-58](https://linear.app/loceract/issue/LOC-58) | 🟩 머지(#63) |
 | PR1 | 벤치 하니스 + faer/fused 패리티 안전망 | 측정근거, N2 선제 | 없음 | — | [LOC-59](https://linear.app/loceract/issue/LOC-59) | 🟦 진행([PR1.md](PR1.md)) |
-| PR2 | ~~faer 제거~~ → **피벗 검토** | N2(+N1) | — | PR1 | [LOC-60](https://linear.app/loceract/issue/LOC-60) | ⏸ 보류(전제 반증) |
+| PR2 | 출시 faer 백엔드 **CI 커버리지** (N2) [faer 유지] | N2 | 낮음 | PR1 ✅ | [LOC-60](https://linear.app/loceract/issue/LOC-60) | 🟦 진행([PR2.md](PR2.md)) |
 | PR3 | decode 버퍼 재사용 | Claim1 | 낮음~중 | 벤치/N3 게이트 | [LOC-61](https://linear.app/loceract/issue/LOC-61) | ⬜ TODO |
 | PR4 | 다중 누산기 언롤(선택) | Claim3 "진짜 NEON" | 중 | PR2 기반, 벤치 게이트 | [LOC-62](https://linear.app/loceract/issue/LOC-62) | ⬜ TODO |
 | PR5 | 위생: 엔디안 정규화 + 손상 로깅 | N5, N6 | 낮음(독립) | — | [LOC-63](https://linear.app/loceract/issue/LOC-63) | ⬜ TODO |

--- a/docs/perf/vector-math-refactor/risk-register.md
+++ b/docs/perf/vector-math-refactor/risk-register.md
@@ -5,10 +5,11 @@
 
 | ID | 리스크 | 발생 PR | 트리거(관측 신호) | 완화 | 롤백 | 상태 |
 |----|--------|---------|-------------------|------|------|------|
-| R1 | faer 제거로 **배치 gemv 미래 경로**를 닫음 | PR2 | 대규모 exact scan 성능 요구가 로드맵에 등장 | 측정 후 그때 재도입(또는 PR2에서 dep만 optional 유지) | faer feature/dep 복구 커밋 | ⬜ 열림 |
-| R2 | release 수치 ~1e-6 변동으로 **결과 순서** 변동 | PR2 | 회귀 테스트에서 top_k 순서 차이 | 코드근거상 컷오프 의존 0 (분석 §3). PR1 패리티(ε)로 등가 증명 | PR2 revert | ⬜ 열림(실효≈0) |
+| R1 | faer 제거로 **배치 gemv 미래 경로**를 닫음 | PR2 | 대규모 exact scan 성능 요구가 로드맵에 등장 | 측정 후 그때 재도입(또는 PR2에서 dep만 optional 유지) | faer feature/dep 복구 커밋 | 🟩 닫힘 — faer 유지 결정(PR1 반증), 경로 보존 |
+| R2 | release 수치 ~1e-6 변동으로 **결과 순서** 변동 | PR2 | 회귀 테스트에서 top_k 순서 차이 | 코드근거상 컷오프 의존 0 (분석 §3). PR1 패리티(ε)로 등가 증명 | PR2 revert | 🟩 닫힘 — faer 유지로 백엔드 교체 없음 |
 | R3 | 고차원·대량 linear scan에서 **스칼라 throughput-bound** | PR2 후 | 벤치에서 1024+ 차원 회귀 | PR4 다중 누산기 언롤 | PR4 미적용 시 기존 fused 유지 | 🟥 PR1 확정(fused가 faer 대비 2–8× 느림) |
-| **R9** | **PR2 전제 반증**: faer 제거가 핫 패스를 회귀시킴(faer가 2–8× 빠름) | PR1 | PR1 벤치 (exact_scan 2.8×, dot 최대 7.8×) | PR2를 “faer 유지 + N2/N1”로 피벗 | — (PR2 미진행) | 🟥 발생함 — 계획 변경 필요 |
+| **R9** | **PR2 전제 반증**: faer 제거가 핫 패스를 회귀시킴(faer가 2–8× 빠름) | PR1 | PR1 벤치 (exact_scan 2.8×, dot 최대 7.8×) | PR2를 “faer 유지 + N2”로 피벗(완료) | — | 🟩 닫힘 — faer 유지 확정, PR2=N2 CI 커버리지 |
+| **N2** | 출시 faer+quant 백엔드가 **CI에서 빌드/테스트 0회** | 상시(출시) | release만 faer 활성, CI는 default/debug | PR2: faer 테스트 + 출시 조합 릴리스 빌드 게이트 | test_ci.sh revert | 🟨 PR2에서 닫는 중 |
 | R4 | PR4 **언롤 새 버그**(remainder/lane 합산 off-by-one) | PR4 | 패리티 테스트 ε 초과 / 단위 테스트 실패 | 스칼라 대비 property/ε 테스트 필수 | PR4 revert(커널은 PR2 상태로) | ⬜ 열림 |
 | R5 | **스택 PR 고아화** (PR4/PR5 base=PR2) | PR2 머지 | PR4/PR5 diff에 PR2 변경분이 섞여 보임 | PR2 머지 직후 base→main retarget | 재타깃 PR | ⬜ 열림 |
 | R6 | PR3 핫 루프 수정으로 **동작 변경** | PR3 | 검색 결과 diff | 결과 동일성 테스트 + N3로 적용 여부 게이트 | PR3 revert | ⬜ 열림 |

--- a/rust_builder/rust/src/api/vector_math.rs
+++ b/rust_builder/rust/src/api/vector_math.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: MIT
 //
 // Shared vector math kernels for retrieval paths.
-// Keeping this module allocation-free helps mobile hot paths.
+//
+// The fallback backend is allocation-free. The shipped `vector_faer` backend
+// trades a small per-call result allocation for SIMD gemm kernels that measure
+// 2-8x faster on the retrieval hot path (see docs/perf/vector-math-refactor).
 
 /// Decode a SQLite `BLOB` column previously written as a native-endian
 /// f32 byte stream back into a `Vec<f32>`. Returns `None` when the

--- a/scripts/test_ci.sh
+++ b/scripts/test_ci.sh
@@ -32,7 +32,25 @@ case "$TARGET" in
       echo "[ci] ERROR: tracked PDF smoke matched 0 tests (renamed/excluded?); failing closed" >&2
       exit 1
     fi
-    cargo build --manifest-path rust_builder/rust/Cargo.toml --release
+    echo "[ci] Running vector_math kernels under the SHIPPED faer backend"
+    # The release app builds with `--features vector_faer,vector_quant_i8` via
+    # cargokit, but plain `cargo build`/`cargo test` use default features, so the
+    # shipped faer kernels are otherwise never exercised in CI. Run the faer-backed
+    # vector_math tests (including the faer<->fused parity net) and fail closed,
+    # same as the PDF smoke above: `cargo test <filter>` exits 0 on zero matches.
+    if ! faer_out="$(cargo test --manifest-path rust_builder/rust/Cargo.toml --lib --features vector_faer vector_math -- --test-threads=1 2>&1)"; then
+      echo "$faer_out"
+      echo "[ci] ERROR: faer-backend vector_math tests failed" >&2
+      exit 1
+    fi
+    echo "$faer_out"
+    if ! grep -Eq 'test result: ok\. [1-9][0-9]* passed' <<<"$faer_out"; then
+      echo "[ci] ERROR: faer vector_math matched 0 tests (renamed/cfg-excluded?); failing closed" >&2
+      exit 1
+    fi
+    # Compile-check the actual shipped feature combo (faer + i8 quant). A
+    # default-feature release build would never cover the backend that ships.
+    cargo build --manifest-path rust_builder/rust/Cargo.toml --release --features vector_faer,vector_quant_i8
     flutter test test/native
     ;;
   integration)


### PR DESCRIPTION
## 무엇 / 왜 (PR2, 재설계)
PR1(#64) 벤치가 원안 전제를 **반증** — faer가 fused보다 **2–8× 빠름**(exact_scan 2.8×). → "faer 제거" 폐기, **faer 유지**. 대신 PR1이 드러낸 **N2 갭**(출시 `vector_faer,vector_quant_i8` 백엔드가 CI에서 빌드/테스트 0회 — CI는 default/debug)을 닫는다.

## 변경 ([scripts/test_ci.sh](../blob/main/scripts/test_ci.sh) native)
1. **faer-백엔드 vector_math 테스트** 실행 — `cargo test --lib --features vector_faer vector_math -- --test-threads=1`, PDF 스모크와 동일 **fail-closed**(≥1 통과 요구). PR1의 faer↔fused 패리티 테스트가 여기서 돎.
2. **출시 조합 릴리스 빌드** 게이트 — `cargo build --release --features vector_faer,vector_quant_i8` (기존 default-feature 빌드 대체).
3. `vector_math.rs` 모듈 doc 정정 — faer 백엔드는 무할당 아님(per-call 할당 ↔ SIMD로 2–8× 빠름).

## 로컬 검증
- `bash -n` OK
- faer 테스트 4개(패리티 포함) green, fail-closed PASS
- `cargo build --release --features vector_faer,vector_quant_i8` 성공(50s, 기존 dead_code 경고만)

## 비고
- 동작 코드 변경 없음(스크립트/테스트/주석). CI native 잡은 faer 컴파일로 다소 길어짐.
- N1(무할당화)은 PR1에서 throughput 무의미 확인 → 범위 제외.

상세: `docs/perf/vector-math-refactor/PR2.md`. 머지는 본인이 직접(CI green 후).