### PR TITLE
docs(perf): finalize vector_math journal — PR1/2/5 merged, LOC-61 discarded

### DIFF
--- a/docs/perf/vector-math-refactor/PR5.md
+++ b/docs/perf/vector-math-refactor/PR5.md
@@ -2,7 +2,8 @@
 
 - 브랜치: `feat/loc-63-hygiene`
 - Linear: [LOC-63](https://linear.app/loceract/issue/LOC-63)
-- 상태: 🟦 진행 (PR 열림, CI green 대기)
+- PR: [#66](https://github.com/dev07060/mobile_rag_engine/pull/66)
+- 상태: 🟩 머지 (CI 6/6 green → main `271f5a7`)
 
 ## 스코프 (백엔드 무관, 독립)
 ### N6 — 손상 블롭 로깅 (실제 코드 변경)
@@ -24,7 +25,7 @@ asymmetric 누락 위험만 있어 **전면 정규화는 하지 않음**. 대신
 - 손상 임베딩: 무음 드롭 → **`log::warn!` 가시화** (동작 동일).
 - 로컬 검증: fallback `cargo test --lib vector_math` 3 green; faer `--features vector_faer` 4 green(패리티 포함);
   `cargo check --features vector_faer,vector_quant_i8` 통과(quant 분기의 헬퍼 호출 포함).
-- CI: (PR #__ green 후 갱신)
+- CI: PR [#66](https://github.com/dev07060/mobile_rag_engine/pull/66) 6/6 green → main 머지(`271f5a7`).
 
 ## 받은 피드백 (리뷰)
 - (PR 리뷰 후 갱신)

--- a/docs/perf/vector-math-refactor/README.md
+++ b/docs/perf/vector-math-refactor/README.md
@@ -24,13 +24,13 @@
 | PR | 제목 | 해소 | 리스크 | 의존 | Linear | 상태 |
 |----|------|------|--------|------|--------|------|
 | PR0 | 작업 저널 스캐폴드 | 보존 체계 | 없음(문서) | — | [LOC-58](https://linear.app/loceract/issue/LOC-58) | 🟩 머지(#63) |
-| PR1 | 벤치 하니스 + faer/fused 패리티 안전망 | 측정근거, N2 선제 | 없음 | — | [LOC-59](https://linear.app/loceract/issue/LOC-59) | 🟦 진행([PR1.md](PR1.md)) |
-| PR2 | 출시 faer 백엔드 **CI 커버리지** (N2) [faer 유지] | N2 | 낮음 | PR1 ✅ | [LOC-60](https://linear.app/loceract/issue/LOC-60) | 🟦 진행([PR2.md](PR2.md)) |
-| PR3 | decode 버퍼 재사용 | Claim1 | 낮음~중 | 벤치/N3 게이트 | [LOC-61](https://linear.app/loceract/issue/LOC-61) | ⏸ 보류(저가치, 다음 세션) |
+| PR1 | 벤치 하니스 + faer/fused 패리티 안전망 | 측정근거, N2 선제 | 없음 | — | [LOC-59](https://linear.app/loceract/issue/LOC-59) | 🟩 머지(#64, [PR1.md](PR1.md)) |
+| PR2 | 출시 faer 백엔드 **CI 커버리지** (N2) [faer 유지] | N2 | 낮음 | PR1 ✅ | [LOC-60](https://linear.app/loceract/issue/LOC-60) | 🟩 머지(#65, [PR2.md](PR2.md)) |
+| PR3 | decode 버퍼 재사용 | Claim1 | 낮음~중 | 벤치/N3 게이트 | [LOC-61](https://linear.app/loceract/issue/LOC-61) | ❌ 폐기(출시 i8 빌드서 f32 decode 비핫, 코드검증) |
 | PR4 | ~~다중 누산기 언롤~~ | — | — | — | [LOC-62](https://linear.app/loceract/issue/LOC-62) | ❌ 폐기(faer 유지로 무의미) |
-| PR5 | 위생: 손상 로깅(N6) + 엔디안 문서화(N5) | N6, N5 | 낮음(독립) | — | [LOC-63](https://linear.app/loceract/issue/LOC-63) | 🟦 진행([PR5.md](PR5.md)) |
+| PR5 | 위생: 손상 로깅(N6) + 엔디안 문서화(N5) | N6, N5 | 낮음(독립) | — | [LOC-63](https://linear.app/loceract/issue/LOC-63) | 🟩 머지(#66, [PR5.md](PR5.md)) |
 
-종료 회고: [RETRO.md](RETRO.md) · 다음 세션 이어가기: [LOC-61](https://linear.app/loceract/issue/LOC-61)(PR3 재평가) + 프로젝트 핸드오프 노트.
+종료 회고: [RETRO.md](RETRO.md) · PR3([LOC-61](https://linear.app/loceract/issue/LOC-61)) ❌ 폐기 확정(RETRO §5) · 잔여(선택): 온디바이스 벤치 / encode 헬퍼 dedup — 프로젝트 핸드오프 노트 참조.
 
 상태 범례: ⬜ TODO · 🟦 진행 · 🟩 머지 · ⏸ 보류 · ❌ 폐기 · PR별 상세는 `PRn.md`
 

--- a/docs/perf/vector-math-refactor/RETRO.md
+++ b/docs/perf/vector-math-refactor/RETRO.md
@@ -7,8 +7,8 @@
 - **PR0** ([#63](https://github.com/dev07060/mobile_rag_engine/pull/63), 🟩): 작업 저널 스캐폴드 — PR 단위 결과/피드백 보존 체계.
 - **PR1** ([#64](https://github.com/dev07060/mobile_rag_engine/pull/64), 🟩): criterion 벤치 + faer/fused 패리티 안전망. **핵심 발견의 출처.**
 - **PR2** ([#65](https://github.com/dev07060/mobile_rag_engine/pull/65), 🟩): 출시 faer+quant 백엔드를 CI에서 빌드+테스트(N2 닫음). *원안 "faer 제거"에서 피벗.*
-- **PR5** ([LOC-63](https://linear.app/loceract/issue/LOC-63), 🟦 머지 대기): 손상 블롭 `log::warn`(N6) + 엔디안 문서화(N5).
-- **PR3** ⏸ 보류(저가치), **PR4** ❌ 폐기(faer 유지로 무의미).
+- **PR5** ([#66](https://github.com/dev07060/mobile_rag_engine/pull/66), 🟩): 손상 블롭 `log::warn`(N6) + 엔디안 문서화(N5).
+- **PR3** ❌ 폐기(출시 i8 빌드서 f32 decode 비핫 — §5), **PR4** ❌ 폐기(faer 유지로 무의미).
 
 ## 2. 측정 결과 (가설 대조)
 - **착수 가설(틀림):** "faer가 1-D 닷에서 fused보다 느리니 제거하고 fused로 통일하면 빨라진다."
@@ -35,7 +35,8 @@
 - 정적 분석은 "무엇이 비싼가"는 잘 잡지만 "무엇이 지배적인가"는 못 잡는다 → 둘을 분리해서 말할 것.
 
 ## 5. 후속 작업 (다음 세션)
-- **[LOC-61] PR3 재평가** (decode 버퍼 재사용): N1 무의미 + N3(i8 우선)로 저가치. 벤치로 f32 decode가 실제 핫임이 입증될 때만. 기본은 폐기 권장.
+- **[LOC-61] PR3 — ❌ 폐기 확정** (2026-05-30, 코드 검증). 출시 빌드(`vector_faer,vector_quant_i8`)에서 per-candidate 스캔의 1차 경로는 `cosine_with_query_norm_i8_blob`(무디코드·무할당, [hybrid_search.rs:281](../../../rust_builder/rust/src/api/hybrid_search.rs)); `decode_f32_embedding`는 i8 blob 누락 시 폴백일 뿐이고, 순수 f32 스캔 루프는 `#[cfg(not(feature="vector_quant_i8"))]`라 릴리스에 컴파일조차 안 됨 → **f32 decode는 출시 핫패스 아님**. Gate2: PR1에서 alloc은 throughput 비지배(faer가 row당 alloc을 더 안고도 2.8× 우세). 두 게이트 모두 실패 → 폐기. 적대적 검증 3개 렌즈 전부 결론 유지.
+  - ⚠️ **dequant ≠ decode 뉘앙스**: 유일하게 출시 빌드에서 row당 `Vec<f32>`를 만드는 곳은 HNSW 빌드 루프지만, i8 빌드의 1차 arm은 `dequantize_i8_to_f32`([vector_quant.rs:34](../../../rust_builder/rust/src/api/vector_quant.rs))로 **이것도 row당 할당**이며 비용은 `Hnsw::insert`가 지배. PR3의 decode 버퍼 재사용은 이 경로에 적용 대상조차 아님. 향후 HNSW-빌드 할당을 미세최적화한다면 타깃은 *dequant* 경로지 decode가 아님.
 - **온디바이스 벤치**: 실제 폰(arm64)에서 faer 우위 크기 확인(선택).
 - **공유 encode 헬퍼**: 5개 인코딩 사이트(`to_ne_bytes`) dedup + 원하면 LE 정규화(저가치).
 - **(선택) N1 무할당 faer**: `faer::linalg::matmul`로 결과 할당 제거 — throughput 무의미하므로 마이크로옵트로만.


### PR DESCRIPTION
Closes out the `docs/perf/vector-math-refactor/` work journal now that PR5 (#66) is merged. Docs-only — no code changes.

## What
- **Status sync to merged reality**: PR1 (#64), PR2 (#65), PR5 (#66) rows were all stale at 🟦 (they merged mid-session after the journal was authored) → flipped to 🟩 in `README.md` / `RETRO.md` / `PR5.md`, with PR links + CI/merge-commit references.
- **LOC-61 (PR3 "decode 버퍼 재사용") resolution → ❌ discard** recorded in `RETRO.md §5` and the README PR3 row.

## Why LOC-61 is discarded (code-verified, no on-device bench needed)
Both gating conditions in the issue fail:
- **Gate 1 — f32 decode is not on the shipped hot path.** Release ships `--features vector_faer,vector_quant_i8`. The per-candidate scan's primary path is `cosine_with_query_norm_i8_blob` (raw i8 blob, no f32 decode, no alloc). `decode_f32_embedding` is only a cfg-gated/data fallback; the unconditional pure-f32 scan loop is `#[cfg(not(feature = "vector_quant_i8"))]` and isn't compiled into the release binary.
- **Gate 2 — per-row alloc is not the throughput-limiting term.** PR1's `exact_scan` runs decode's alloc 2000×/iter plus faer's ~4000 allocs/iter and faer still wins 2.8×.

Adversarial review (shipped-build-reality / throughput-causality / scope-correctness) upheld discard on all three lenses. Nuance preserved: the only shipped per-row `Vec<f32>` materialization is the HNSW build loop, but its primary i8 arm is `dequantize_i8_to_f32` (which also allocates) and cost is dominated by `Hnsw::insert` — so PR3's decode-buffer reuse wouldn't even apply. If HNSW-build allocation ever matters, the target is *dequant*, not decode.

## Linear
LOC-58/59/60/63 → Done; LOC-61 → Canceled (discard rationale posted as a comment). LOC-62 already Canceled.