### PR TITLE
feat(profiling): query profile report model + JSON/CSV (LOC-66, P1)

### DIFF
--- a/example/lib/profiling/query_profile_report.dart
+++ b/example/lib/profiling/query_profile_report.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+import 'package:mobile_rag_engine/services/benchmark_service.dart';
+import 'package:mobile_rag_engine/models/benchmark_models.dart';
+
+/// Per-segment sample collector; defers stats to BenchmarkService.summarizeSamples.
+class SegmentSamples {
+  final String segment;
+  final List<double> samplesMs = [];
+  SegmentSamples(this.segment);
+  void add(double ms) => samplesMs.add(ms);
+  void addAll(Iterable<double> ms) => samplesMs.addAll(ms);
+
+  DetailedBenchmarkStats stats() =>
+      BenchmarkService.summarizeSamples(samplesMs, warmupIterations: 0);
+
+  Map<String, dynamic> toJson() {
+    final s = stats();
+    return {'segment': segment, ...s.toJson()};
+  }
+}
+
+/// One scenario run: a (lane, category) cell with its measured segments.
+class QueryProfileRun {
+  final String lane;       // 'unfiltered' | 'filtered'
+  final String category;   // 'pure_cold' | 'switching_cold' | 'pure_warm'
+  final Map<String, SegmentSamples> segments;
+  final Map<String, Object?> io;   // query_metrics snapshot
+  final Map<String, Object?> meta; // device/config
+
+  QueryProfileRun({
+    required this.lane, required this.category,
+    required this.segments, required this.io, required this.meta,
+  });
+
+  /// FFI marshalling + isolate context-switch cost = Dart-measured - Rust-internal.
+  /// Clamped to 0 (clock noise can make it slightly negative).
+  static double ffiOverheadMs({required double dartMs, required double rustInternalMs}) {
+    final d = dartMs - rustInternalMs;
+    return d > 0 ? d : 0.0;
+  }
+
+  Map<String, dynamic> toJson() => {
+    'lane': lane,
+    'category': category,
+    'segments': segments.map((k, v) => MapEntry(k, v.toJson())),
+    'io': io,
+    'meta': meta,
+  };
+}
+
+class QueryProfileReport {
+  final List<QueryProfileRun> runs;
+  QueryProfileReport({required this.runs});
+
+  Map<String, dynamic> toJson() => {'runs': runs.map((r) => r.toJson()).toList()};
+  String toJsonString() => const JsonEncoder.withIndent('  ').convert(toJson());
+
+  String toCsv() {
+    final b = StringBuffer()
+      ..writeln('lane,category,segment,p50_ms,p95_ms,avg_ms,min_ms,max_ms,stddev_ms,n');
+    for (final r in runs) {
+      for (final seg in r.segments.values) {
+        final s = seg.stats();
+        b.writeln('${r.lane},${r.category},${seg.segment},'
+            '${s.p50Ms},${s.p95Ms},${s.avgMs},${s.minMs},${s.maxMs},${s.stdDevMs},'
+            '${s.measuredIterations}');
+      }
+    }
+    return b.toString();
+  }
+}

--- a/example/test/profiling/query_profile_report_test.dart
+++ b/example/test/profiling/query_profile_report_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_rag_engine_example/profiling/query_profile_report.dart';
+
+void main() {
+  test('SegmentSamples aggregates and serializes', () {
+    final seg = SegmentSamples('embed')..addAll([10, 12, 11, 13, 9]);
+    final j = seg.toJson();
+    expect(j['segment'], 'embed');
+    expect(j['p50_ms'], isNotNull);
+    expect((j['samples_ms'] as List).length, 5);
+  });
+
+  test('ffiOverheadMs = dart segment minus rust internal', () {
+    expect(QueryProfileRun.ffiOverheadMs(dartMs: 5.0, rustInternalMs: 3.2), closeTo(1.8, 1e-6));
+    expect(QueryProfileRun.ffiOverheadMs(dartMs: 3.0, rustInternalMs: 3.4), 0.0);
+  });
+
+  test('empty SegmentSamples serializes to zero stats', () {
+    final seg = SegmentSamples('embed');
+    final j = seg.toJson();
+    expect(j['segment'], 'embed');
+    expect(j['p50_ms'], 0.0);
+    expect((j['samples_ms'] as List).isEmpty, true);
+  });
+
+  test('report toCsv has one row per (lane,category,segment) + toJson', () {
+    final run = QueryProfileRun(
+      lane: 'unfiltered', category: 'pure_warm',
+      segments: {
+        'embed': SegmentSamples('embed')..addAll([10, 11]),
+        'search': SegmentSamples('search')..addAll([2, 3]),
+      },
+      io: const {'scoped_exact_scan_rows': 0},
+      meta: const {'device': 'test'},
+    );
+    final report = QueryProfileReport(runs: [run]);
+    final csv = report.toCsv();
+    expect(csv, contains('lane,category,segment,p50_ms,p95_ms,avg_ms,min_ms,max_ms,stddev_ms,n'));
+    expect(csv, contains('unfiltered,pure_warm,embed,'));
+    expect(csv, contains('unfiltered,pure_warm,search,'));
+    expect((report.toJson()['runs'] as List).length, 1);
+  });
+}


### PR DESCRIPTION
## P1 of 온디바이스 쿼리 프로파일러 (host-only, no device)
프로파일러의 결과 모델 + 직렬화. 순수 로직, 기기 불필요.

- `example/lib/profiling/query_profile_report.dart`: SegmentSamples / QueryProfileRun / QueryProfileReport — 세그먼트 샘플을 **기존 `BenchmarkService.summarizeSamples`로 집계**(중복 stats 메서드 추가 안 함), JSON/CSV 직렬화, `ffiOverheadMs`(Dart−Rust, clamp 0).
- `example/test/profiling/query_profile_report_test.dart`: 4 테스트(집계/직렬화, ffiOverhead+clamp, CSV행+toJson, empty-segment) — **4/4 green**.

## 계획 대비 변경 (DRY)
원안 P1.1 `statsFromSamples`는 **폐기** — 기존 `summarizeSamples(samples, warmupIterations:0)`가 동일 기능. 중복 제거.

## 리뷰
spec-compliance ✅ / code-quality ✅ (analyzer clean). Claude 귀속 없음.

## 머지 순서
이 PR은 `example/`만 건드려 #69(스펙+계획 docs)와 **충돌 없음·독립** — 순서 무관. 저널 PR-P1.md/README 행 동기화는 #69 머지 후 정리.
P2–P4는 **실기 연결 후** 진행. 머지는 본인(CI green 후).