### PR TITLE
docs: add iOS static linkage troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ dependencies:
   mobile_rag_engine: ^0.20.0
 ```
 
+> **iOS Setup:** Open your `ios/Podfile` and change `use_frameworks!` to `use_frameworks! :linkage => :static`. This is required because the underlying ONNX Runtime uses statically linked binaries.
+
 ### 2. Download Model Files
 
 ```bash

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -260,6 +260,22 @@ dyld: Library not loaded: @rpath/libonnxruntime.dylib
 
 ## Build Issues
 
+### iOS: Transitive dependencies include statically linked binaries
+
+**Symptom:**
+```
+[!] The 'Pods-Runner' target has transitive dependencies that include statically linked binaries: (onnxruntime-objc and onnxruntime-c)
+```
+
+**Cause:** `mobile_rag_engine` (since 0.19.0) uses `flutter_onnxruntime` which relies on statically linked ONNX Runtime binaries. Flutter's default iOS project uses dynamic frameworks (`use_frameworks!`).
+
+**Solution:** Update your `ios/Podfile` to use static linkage for frameworks:
+1. Open `ios/Podfile`
+2. Change `use_frameworks!` to `use_frameworks! :linkage => :static`
+3. Run `pod install` again.
+
+---
+
 ### iOS: Pod Install Failed
 
 ```bash


### PR DESCRIPTION
Added documentation for the `use_frameworks! :linkage => :static` workaround needed for iOS pod install due to the statically linked ONNX Runtime binaries.